### PR TITLE
feat: create terraform confirg for o11y

### DIFF
--- a/clusters/cluster-o11y/.gitignore
+++ b/clusters/cluster-o11y/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/clusters/cluster-o11y/.terraform.lock.hcl
+++ b/clusters/cluster-o11y/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/linode/linode" {
+  version     = "2.3.0"
+  constraints = "2.3.0"
+  hashes = [
+    "h1:Bfs5V+tu99Jk9g8epXn53sZGhxLYo9MVy0KXljWDnfI=",
+    "zh:0b4344d106be4ae941a6addb244b9b631970bcefe982be88683511c06801a3c1",
+    "zh:0c0ff151166711bbaad5dc6912bb1c26f63fd6a6a82320d22b348974b7ac043a",
+    "zh:22556c5e24b0cd6ead0b806339752d6a71f8aa391fd120b7ce60596819e34145",
+    "zh:335309506fe846ec35fb75763d4faaf434e6e0cba7f8a1801311331717b2e798",
+    "zh:43e1662258d93a4fa551fe939ad47d8d324b3bd64c710dc978d33f7247f6ad9e",
+    "zh:47e86ac77b7886fac00c4319372a24e2a7aa7888b7392c829311241782ea7622",
+    "zh:5759269e96d373f49967992081f33ad5fac6a00fee4ea84ab8f22cfbee6fc8fb",
+    "zh:83aec2a5c619fdcbdd41191b9ff5527893ad17df00fb9e7f007f95c6fa3fca6c",
+    "zh:965e82a8f188ec03c81eba944ea336e76ee578261ae6a1567ae811187903397a",
+    "zh:98b165d121d4e1466feae542e09e573b0ac2b1870854bc2fa689d0bde7d874a3",
+    "zh:b54d9fc0153d25eda3925a2bdf78a76745f2d7c4d964bbe5f027eedc7b1d2958",
+    "zh:bcc2ec0d4f811a2d05cdcf2626e6998e2e7e0485f9771732978570d8ce446328",
+    "zh:cda016bca293e4ed56d82b51baa7a6b589c11fa3712fdd6aa61a6fd447a257b7",
+    "zh:e45dd2013ce633b8b8f9c33e9746b4f6b3087a3d55d8bbf857663ff91d989d27",
+  ]
+}

--- a/clusters/cluster-o11y/backend.tf
+++ b/clusters/cluster-o11y/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "freecodecamp"
+
+    workspaces {
+      name = "tfws-monitoring"
+    }
+  }
+}

--- a/clusters/cluster-o11y/main.tf
+++ b/clusters/cluster-o11y/main.tf
@@ -1,0 +1,59 @@
+resource "linode_instance" "ops_o11y_workers" {
+  count     = var.worker_node_count
+  image     = var.image_id
+  label     = "ops-vm-o11y-wkr-${count.index + 1}"
+  group     = "ops-o11y"
+  region    = var.region
+  type      = "g6-standard-2"
+  root_pass = var.password
+
+  connection {
+    type     = "ssh"
+    user     = "root"
+    password = var.password
+    host     = self.ip_address
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      # Update the system.
+      "apt-get update -qq",
+      # Disable password authentication; users can only connect with an SSH key.
+      "sed -i '/PasswordAuthentication/d' /etc/ssh/sshd_config",
+      "echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config",
+      "apt-get install -y ssh-import-id",
+      # Import the public keys for the users specified in the import_ssh_users variable.
+      "ssh-import-id ${join(",", var.import_ssh_users)}",
+    ]
+  }
+}
+
+resource "linode_instance" "ops_o11y_leaders" {
+  count     = var.leader_node_count
+  image     = var.image_id
+  label     = "ops-vm-o11y-wkr-${count.index + 1}"
+  group     = "ops-o11y"
+  region    = var.region
+  type      = "g6-standard-2"
+  root_pass = var.password
+
+  connection {
+    type     = "ssh"
+    user     = "root"
+    password = var.password
+    host     = self.ip_address
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      # Update the system.
+      "apt-get update -qq",
+      # Disable password authentication; users can only connect with an SSH key.
+      "sed -i '/PasswordAuthentication/d' /etc/ssh/sshd_config",
+      "echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config",
+      "apt-get install -y ssh-import-id",
+      # Import the public keys for the users specified in the import_ssh_users variable.
+      "ssh-import-id ${join(",", var.import_ssh_users)}",
+    ]
+  }
+}

--- a/clusters/cluster-o11y/providers.tf
+++ b/clusters/cluster-o11y/providers.tf
@@ -1,0 +1,3 @@
+provider "linode" {
+  token = var.linode_token
+}

--- a/clusters/cluster-o11y/terraform.tfvars.sample
+++ b/clusters/cluster-o11y/terraform.tfvars.sample
@@ -1,0 +1,6 @@
+linode_token = "<LinodeApiToken>"
+password = "<RootPassword>"
+worker_node_count = 3
+leader_node_count = 1
+image_id = "private/<LinodeImageId>"
+import_ssh_users = ["gh:someuser", "raisedadead"]

--- a/clusters/cluster-o11y/variables.tf
+++ b/clusters/cluster-o11y/variables.tf
@@ -1,0 +1,31 @@
+variable "linode_token" {
+  description = "The Linode API Personal Access Token."
+}
+
+variable "password" {
+  description = "The root password for the Linode instances."
+}
+
+variable "import_ssh_users" {
+  description = "The users to import their public keys to the Linode instances with ssh-import-id."
+}
+
+variable "worker_node_count" {
+  description = "The number of worker instances to create."
+  default     = 3
+}
+
+variable "leader_node_count" {
+  description = "The number of leader instances to create."
+  default     = 1
+}
+
+variable "region" {
+  description = "The name of the region in which to deploy instances."
+  default     = "us-east"
+}
+
+variable "image_id" {
+  description = "The ID for the Linode image to be used in provisioning the instances"
+  default     = "linode/ubuntu20.04"
+}

--- a/clusters/cluster-o11y/versions.tf
+++ b/clusters/cluster-o11y/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    linode = {
+      source  = "linode/linode"
+      version = "2.3.0"
+    }
+  }
+  required_version = ">= 1"
+}


### PR DESCRIPTION
This just adds terraform configs to create a bunch of VMs. I think I will add the Ansible scripts to provision the monitoring stack in later PRs.