### PR TITLE
fix(ansible,docker,swarm): improved IP management

### DIFF
--- a/ansible/play-o11y--0-initialize.yml
+++ b/ansible/play-o11y--0-initialize.yml
@@ -1,5 +1,5 @@
 ---
-- name: Initialize a O11y Cluster
+- name: Initialize O11y Cluster
   hosts: all
   become: true
   roles:

--- a/ansible/play-test--0-docker-swarm.yml
+++ b/ansible/play-test--0-docker-swarm.yml
@@ -9,7 +9,7 @@
     purge_test: '{{ variable_purge_test | default(true) }}'
 
   roles:
-    - ubuntu # Update the OS and reboot the server
+    # - ubuntu # Update the OS and reboot the server
     - dns # Configure ansible facts for networking info lookup
     - docker # Intialize docker and docker swarm cluster
 

--- a/ansible/roles/docker/tasks/install-swarm.yml
+++ b/ansible/roles/docker/tasks/install-swarm.yml
@@ -1,34 +1,45 @@
 # tasks file for roles/swarm
 ---
-- name: Retrieve the initial Swarm Info
-  community.docker.docker_swarm_info:
-  register: swarm_info_initial
-  when: inventory_hostname == groups['managers'][0]
-  ignore_errors: true
+- name: Gather network interfaces facts
+  ansible.builtin.setup:
+    gather_subset:
+      - network
   no_log: "{{ variable_no_log | default (true) }}"
-  changed_when: swarm_info_initial.docker_swarm_active == false
+  when: inventory_hostname in groups['managers']
 
-- name: Initialize Swarm
+- name: Check if eth1 (private vlan) exists
+  set_fact:
+    eth1_exists: true
+  when: inventory_hostname in groups['managers'] and "'eth1' in ansible_interfaces"
+
+- name: Set the management IP address for swarm on managers
+  set_fact:
+    mgmt_listen_ip: "{{ eth1_exists | ternary( ansible_eth1.ipv4.address, ansible_default_ipv4.address) }}"
+  when: inventory_hostname in groups['managers']
+
+- name: Initialize a Docker Swarm
   community.docker.docker_swarm:
     state: present
-    advertise_addr: "{{ ansible_default_ipv4.address }}"
-    listen_addr: "{{ ansible_default_ipv4.address }}:2377"
-  when: inventory_hostname == groups['managers'][0] and swarm_info_initial.docker_swarm_active == false
+    advertise_addr: "{{ mgmt_listen_ip }}"
+    listen_addr: "{{ mgmt_listen_ip }}:2377"
+  when: inventory_hostname == groups['managers'][0]
   no_log: "{{ variable_no_log | default (true) }}"
 
-- name: Refresh the Swarm Info
+- name: Retrieve the Swarm Info
   community.docker.docker_swarm_info:
     nodes: true
   register: swarm_info
   when: inventory_hostname == groups['managers'][0]
   no_log: "{{ variable_no_log | default (true) }}"
 
-# TODO: Add checks and add more managers if needed
+  # TODO: Add checks and add more managers if needed
+  # - name: Set useful information on Managers as Facts
+  # - name: Join Swarm as manager using token
 
 - name: Set useful information on Workers as Facts
   set_fact:
     swarm_join_token_worker: "{{ hostvars[groups['managers'][0]]['swarm_info']['swarm_facts']['JoinTokens']['Worker'] }}"
-    swarm_manager_addr: "{{ hostvars[groups['managers'][0]]['ansible_default_ipv4']['address'] }}"
+    swarm_manager_addr: "{{ hostvars[groups['managers'][0]]['mgmt_listen_ip'] }}"
   when: inventory_hostname in groups['workers']
   no_log: "{{ variable_no_log | default (true) }}"
 
@@ -52,4 +63,4 @@
 - name: Print Swarm Nodes
   debug:
     msg: "{{ result.nodes }}"
-  when: inventory_hostname == groups['managers'][0]
+  when: inventory_hostname in groups['managers']

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -3,6 +3,7 @@
   stat:
     path: /usr/bin/docker
   register: docker_installed
+  no_log: "{{ variable_no_log | default (true) }}"
 
 - name: Install Docker if not installed using the role
   include_role:


### PR DESCRIPTION
This makes the swarm initialization a bit nicer by using the `eth1` interface we use for VLAN when available.