### PR TITLE
feat(terraform): use HCP Packer images for clusters

### DIFF
--- a/packer/linode/scripts/ansible/install-docker.yml
+++ b/packer/linode/scripts/ansible/install-docker.yml
@@ -41,5 +41,5 @@
       changed_when: docker_install.stdout.find('Setting up docker-ce') != -1
 
     - name: Install Docker Module for Python
-      pip:
+      ansible.builtin.pip:
         name: docker

--- a/packer/linode/ubuntu.pkr.hcl
+++ b/packer/linode/ubuntu.pkr.hcl
@@ -94,7 +94,7 @@ build {
     bucket_name = "linode-ubuntu"
 
     description = <<EOT
-An Ubuntu 22.04 LTS image with Docker installed.
+An Ubuntu LTS - Server image with Docker installed.
     EOT
 
     bucket_labels = {

--- a/terraform/ops-cluster-o11y/.terraform.lock.hcl
+++ b/terraform/ops-cluster-o11y/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/hcp" {
+  version     = "0.63.0"
+  constraints = "0.63.0"
+  hashes = [
+    "h1:s1juXIs3K6hKrA159enQsSDdQs94v/i5z7cag5fEmao=",
+    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
+    "zh:1d83a8d6b898cc93b1c613f7efd98de39c44e0caf824ed17acbbab94b1d21be0",
+    "zh:3f492033c6a7b09482daca5124229fae4b33f26de655f5ca88187d3e7dbdfb01",
+    "zh:571815d60b74aa9fa70b83730ddc4ec2ecc2b7537002fa52e4bf3381443485f6",
+    "zh:772f46ecc6e1cf0d419efd3535c5e8810039cde8b352f9af90b6bf20008aca4f",
+    "zh:a10eb1843611949a2bc1dea34227cb67cefab74a51b6b641c145c76529e743ce",
+    "zh:b2e816c8f872fe381c0b8620c92eb8db59c4f122bc917e2fa9747b55741cde2c",
+    "zh:cb18fdb884205ac3245dfdfbcdc7b05cdab3bc8b84293e68433a4831489ec075",
+    "zh:dae6cb2056a9f6ca23b6f34972ee2fe5d618161871e3b4942fb706924e09f2f9",
+    "zh:ed630d2fe6f1305cc47ffe0d7dc919c53c1d48ad6f49400d5baee853387d4dcb",
+    "zh:f7fa21d75f71849799c3067bd95f3d5ca60e7a5525ea3964713fc1ebda70cc51",
+    "zh:f97c75332a07acb24c69e4a89cc0a76b0e40b5d2e4634e6dd57e710b47b8f133",
+  ]
+}
+
 provider "registry.terraform.io/linode/linode" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/terraform/ops-cluster-o11y/main.tf
+++ b/terraform/ops-cluster-o11y/main.tf
@@ -23,13 +23,20 @@ resource "linode_instance" "ops_o11y_leaders" {
   tags = ["ops", "o11y", "o11y_leader"] # tags should use underscores for Ansible compatibility
 }
 
+data "hcp_packer_image" "linode-ubuntu" {
+  bucket_name    = "linode-ubuntu"
+  channel        = "latest"
+  cloud_provider = "linode"
+  region         = "us-east"
+}
+
 resource "linode_instance_disk" "ops_o11y_leaders_disk__boot" {
   count     = var.leader_node_count
   label     = "ops-vm-o11y-ldr-${count.index + 1}-boot"
   linode_id = linode_instance.ops_o11y_leaders[count.index].id
   size      = linode_instance.ops_o11y_leaders[count.index].specs.0.disk
 
-  image     = var.image_id
+  image     = data.hcp_packer_image.linode-ubuntu.cloud_image_id
   root_pass = var.password
 
   stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id
@@ -132,7 +139,7 @@ resource "linode_instance_disk" "ops_o11y_workers_disk__boot" {
   linode_id = linode_instance.ops_o11y_workers[count.index].id
   size      = linode_instance.ops_o11y_workers[count.index].specs.0.disk
 
-  image     = var.image_id
+  image     = data.hcp_packer_image.linode-ubuntu.cloud_image_id
   root_pass = var.password
 
   stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id

--- a/terraform/ops-cluster-o11y/providers.tf
+++ b/terraform/ops-cluster-o11y/providers.tf
@@ -1,3 +1,9 @@
 provider "linode" {
   token = var.linode_token
 }
+
+provider "hcp" {
+  client_id     = var.hcp_client_id
+  client_secret = var.hcp_client_secret
+  project_id    = "377fca8e-97bb-4058-ae1b-2845bac3c6bc" # ops
+}

--- a/terraform/ops-cluster-o11y/terraform.tfvars.sample
+++ b/terraform/ops-cluster-o11y/terraform.tfvars.sample
@@ -1,4 +1,7 @@
 linode_token = "<LinodeApiToken>"
 password = "<RootPassword>"
 
+hcp_client_id = "<HCPClientId>"
+hcp_client_secret = "<HCPClientSecret>"
+
 # Override any more variables from the variables.tf file here

--- a/terraform/ops-cluster-o11y/variables.tf
+++ b/terraform/ops-cluster-o11y/variables.tf
@@ -36,8 +36,18 @@ variable "region" {
   type        = string
 }
 
-variable "image_id" {
-  description = "The ID for the Linode image to be used in provisioning the instances"
-  default     = "private/20789403"
+# variable "image_id" {
+#   description = "The ID for the Linode image to be used in provisioning the instances"
+#   default     = "private/20789403"
+#   type        = string
+# }
+
+variable "hcp_client_id" {
+  description = "The client ID for the HCP API."
+  type        = string
+}
+
+variable "hcp_client_secret" {
+  description = "The client secret for the HCP API."
   type        = string
 }

--- a/terraform/ops-cluster-o11y/versions.tf
+++ b/terraform/ops-cluster-o11y/versions.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "linode/linode"
       version = "2.5.1"
     }
+
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "0.63.0"
+    }
   }
   required_version = ">= 1"
 }

--- a/terraform/ops-test/.terraform.lock.hcl
+++ b/terraform/ops-test/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/hcp" {
+  version     = "0.63.0"
+  constraints = "0.63.0"
+  hashes = [
+    "h1:s1juXIs3K6hKrA159enQsSDdQs94v/i5z7cag5fEmao=",
+    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
+    "zh:1d83a8d6b898cc93b1c613f7efd98de39c44e0caf824ed17acbbab94b1d21be0",
+    "zh:3f492033c6a7b09482daca5124229fae4b33f26de655f5ca88187d3e7dbdfb01",
+    "zh:571815d60b74aa9fa70b83730ddc4ec2ecc2b7537002fa52e4bf3381443485f6",
+    "zh:772f46ecc6e1cf0d419efd3535c5e8810039cde8b352f9af90b6bf20008aca4f",
+    "zh:a10eb1843611949a2bc1dea34227cb67cefab74a51b6b641c145c76529e743ce",
+    "zh:b2e816c8f872fe381c0b8620c92eb8db59c4f122bc917e2fa9747b55741cde2c",
+    "zh:cb18fdb884205ac3245dfdfbcdc7b05cdab3bc8b84293e68433a4831489ec075",
+    "zh:dae6cb2056a9f6ca23b6f34972ee2fe5d618161871e3b4942fb706924e09f2f9",
+    "zh:ed630d2fe6f1305cc47ffe0d7dc919c53c1d48ad6f49400d5baee853387d4dcb",
+    "zh:f7fa21d75f71849799c3067bd95f3d5ca60e7a5525ea3964713fc1ebda70cc51",
+    "zh:f97c75332a07acb24c69e4a89cc0a76b0e40b5d2e4634e6dd57e710b47b8f133",
+  ]
+}
+
 provider "registry.terraform.io/linode/linode" {
   version     = "2.5.1"
   constraints = "2.5.1"

--- a/terraform/ops-test/main.tf
+++ b/terraform/ops-test/main.tf
@@ -22,12 +22,19 @@ resource "linode_instance" "ops_test" {
   tags = ["ops", "test"] # tags should use underscores for Ansible compatibility
 }
 
+data "hcp_packer_image" "linode-ubuntu" {
+  bucket_name    = "linode-ubuntu"
+  channel        = "latest"
+  cloud_provider = "linode"
+  region         = "us-east"
+}
+
 resource "linode_instance_disk" "ops_test_disk__boot" {
   label     = "ops-vm-test-boot"
   linode_id = linode_instance.ops_test.id
   size      = linode_instance.ops_test.specs.0.disk
 
-  image     = var.image_id
+  image     = data.hcp_packer_image.linode-ubuntu.cloud_image_id
   root_pass = var.password
 
   stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id

--- a/terraform/ops-test/providers.tf
+++ b/terraform/ops-test/providers.tf
@@ -1,3 +1,9 @@
 provider "linode" {
   token = var.linode_token
 }
+
+provider "hcp" {
+  client_id     = var.hcp_client_id
+  client_secret = var.hcp_client_secret
+  project_id    = "377fca8e-97bb-4058-ae1b-2845bac3c6bc" # ops
+}

--- a/terraform/ops-test/terraform.tfvars.sample
+++ b/terraform/ops-test/terraform.tfvars.sample
@@ -1,4 +1,7 @@
 linode_token = "<LinodeApiToken>"
 password = "<RootPassword>"
 
+hcp_client_id = "<HCPClientId>"
+hcp_client_secret = "<HCPClientSecret>"
+
 # Override any more variables from the variables.tf file here

--- a/terraform/ops-test/variables.tf
+++ b/terraform/ops-test/variables.tf
@@ -14,8 +14,18 @@ variable "region" {
   type        = string
 }
 
-variable "image_id" {
-  description = "The ID for the Linode image to be used in provisioning the instances"
-  default     = "private/20789403"
+# variable "image_id" {
+#   description = "The ID for the Linode image to be used in provisioning the instances"
+#   default     = "private/20789403"
+#   type        = string
+# }
+
+variable "hcp_client_id" {
+  description = "The client ID for the HCP API."
+  type        = string
+}
+
+variable "hcp_client_secret" {
+  description = "The client secret for the HCP API."
   type        = string
 }

--- a/terraform/ops-test/versions.tf
+++ b/terraform/ops-test/versions.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "linode/linode"
       version = "2.5.1"
     }
+
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "0.63.0"
+    }
   }
   required_version = ">= 1"
 }


### PR DESCRIPTION
This PR enables using the cloud images from the HCP Packer registry for better discovery and updates
