### PR TITLE
fix(terraform): use update APIs and images

### DIFF
--- a/terraform/stg-cluster-mintworld/main.tf
+++ b/terraform/stg-cluster-mintworld/main.tf
@@ -18,12 +18,11 @@ data "linode_stackscripts" "cloudinit_scripts" {
     values = ["false"]
   }
 }
-
-data "hcp_packer_image" "linode_ubuntu" {
-  bucket_name    = "linode-ubuntu"
-  channel        = "golden"
-  cloud_provider = "linode"
-  region         = "us-east"
+data "hcp_packer_artifact" "linode_ubuntu_artifact" {
+  platform     = "linode"
+  bucket_name  = "linode-ubuntu"
+  region       = "us-east"
+  channel_name = "latest"
 }
 
 locals {

--- a/terraform/stg-cluster-mintworld/next-01-nomad-servers.tf
+++ b/terraform/stg-cluster-mintworld/next-01-nomad-servers.tf
@@ -30,7 +30,7 @@ resource "linode_instance_disk" "stg_mintworld_nomad_svr_disk__boot" {
   linode_id = linode_instance.stg_mintworld_nomad_svr[count.index].id
   size      = linode_instance.stg_mintworld_nomad_svr[count.index].specs.0.disk
 
-  image     = data.hcp_packer_image.linode_ubuntu.cloud_image_id
+  image     = data.hcp_packer_artifact.linode_ubuntu_artifact.external_identifier
   root_pass = var.password
 
   stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id

--- a/terraform/stg-cluster-mintworld/next-02-consul-servers.tf
+++ b/terraform/stg-cluster-mintworld/next-02-consul-servers.tf
@@ -30,7 +30,7 @@ resource "linode_instance_disk" "stg_mintworld_consul_svr_disk__boot" {
   linode_id = linode_instance.stg_mintworld_consul_svr[count.index].id
   size      = linode_instance.stg_mintworld_consul_svr[count.index].specs.0.disk
 
-  image     = data.hcp_packer_image.linode_ubuntu.cloud_image_id
+  image     = data.hcp_packer_artifact.linode_ubuntu_artifact.external_identifier
   root_pass = var.password
 
   stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id

--- a/terraform/stg-cluster-mintworld/next-03-workers.tf
+++ b/terraform/stg-cluster-mintworld/next-03-workers.tf
@@ -30,7 +30,7 @@ resource "linode_instance_disk" "stg_mintworld_cluster_wkr_disk__boot" {
   linode_id = linode_instance.stg_mintworld_cluster_wkr[count.index].id
   size      = linode_instance.stg_mintworld_cluster_wkr[count.index].specs.0.disk
 
-  image     = data.hcp_packer_image.linode_ubuntu.cloud_image_id
+  image     = data.hcp_packer_artifact.linode_ubuntu_artifact.external_identifier
   root_pass = var.password
 
   stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id


### PR DESCRIPTION
This PR swaps the soon to be deprecated `hcp_packer_image` data source with the `hcp_packer_artifact` data source for HCP Imagesfor linode. 
