### PR TITLE
fix(terraform): use linode instance metadata

### DIFF
--- a/terraform/stg-cluster-mintworld/next-01-nomad-servers.tf
+++ b/terraform/stg-cluster-mintworld/next-01-nomad-servers.tf
@@ -17,6 +17,14 @@ resource "linode_instance" "stg_mintworld_nomad_svr" {
   # Value should use '_' as sepratator for compatibility with Ansible Dynamic Inventory
   group = "stg_mintworld_nomad_svr"
 
+  metadata {
+    user_data = base64encode(
+      templatefile("${path.root}/cloud-init--userdata.yml.tftpl", {
+        tf_hostname = "nomad-svr-${count.index + 1}.mintworld.stg.${local.zone}"
+      })
+    )
+  }
+
   lifecycle {
     ignore_changes = [
       migration_type
@@ -32,15 +40,6 @@ resource "linode_instance_disk" "stg_mintworld_nomad_svr_disk__boot" {
 
   image     = data.hcp_packer_artifact.linode_ubuntu_artifact.external_identifier
   root_pass = var.password
-
-  stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id
-  stackscript_data = {
-    userdata = base64encode(
-      templatefile("${path.root}/cloud-init--userdata.yml.tftpl", {
-        tf_hostname = "nomad-svr-${count.index + 1}.mintworld.stg.${local.zone}"
-      })
-    )
-  }
 }
 
 resource "linode_instance_config" "stg_mintworld_nomad_svr_config" {
@@ -96,7 +95,7 @@ resource "linode_instance_config" "stg_mintworld_nomad_svr_config" {
     updatedb_disabled = true
   }
 
-  kernel = "linode/grub2"
+  kernel = "linode/latest-64bit"
   booted = true
 
   lifecycle {

--- a/terraform/stg-cluster-mintworld/next-02-consul-servers.tf
+++ b/terraform/stg-cluster-mintworld/next-02-consul-servers.tf
@@ -17,6 +17,14 @@ resource "linode_instance" "stg_mintworld_consul_svr" {
   # Value should use '_' as sepratator for compatibility with Ansible Dynamic Inventory
   group = "stg_mintworld_consul_svr"
 
+  metadata {
+    user_data = base64encode(
+      templatefile("${path.root}/cloud-init--userdata.yml.tftpl", {
+        tf_hostname = "nomad-svr-${count.index + 1}.mintworld.stg.${local.zone}"
+      })
+    )
+  }
+
   lifecycle {
     ignore_changes = [
       migration_type
@@ -32,15 +40,6 @@ resource "linode_instance_disk" "stg_mintworld_consul_svr_disk__boot" {
 
   image     = data.hcp_packer_artifact.linode_ubuntu_artifact.external_identifier
   root_pass = var.password
-
-  stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id
-  stackscript_data = {
-    userdata = base64encode(
-      templatefile("${path.root}/cloud-init--userdata.yml.tftpl", {
-        tf_hostname = "consul-svr-${count.index + 1}.mintworld.stg.${local.zone}"
-      })
-    )
-  }
 }
 
 resource "linode_instance_config" "stg_mintworld_consul_svr_config" {
@@ -96,7 +95,7 @@ resource "linode_instance_config" "stg_mintworld_consul_svr_config" {
     updatedb_disabled = true
   }
 
-  kernel = "linode/grub2"
+  kernel = "linode/latest-64bit"
   booted = true
 
   lifecycle {

--- a/terraform/stg-cluster-mintworld/next-03-workers.tf
+++ b/terraform/stg-cluster-mintworld/next-03-workers.tf
@@ -17,6 +17,14 @@ resource "linode_instance" "stg_mintworld_cluster_wkr" {
   # Value should use '_' as sepratator for compatibility with Ansible Dynamic Inventory
   group = "stg_mintworld_cluster_wkr"
 
+  metadata {
+    user_data = base64encode(
+      templatefile("${path.root}/cloud-init--userdata.yml.tftpl", {
+        tf_hostname = "nomad-svr-${count.index + 1}.mintworld.stg.${local.zone}"
+      })
+    )
+  }
+
   lifecycle {
     ignore_changes = [
       migration_type
@@ -32,15 +40,6 @@ resource "linode_instance_disk" "stg_mintworld_cluster_wkr_disk__boot" {
 
   image     = data.hcp_packer_artifact.linode_ubuntu_artifact.external_identifier
   root_pass = var.password
-
-  stackscript_id = data.linode_stackscripts.cloudinit_scripts.stackscripts.0.id
-  stackscript_data = {
-    userdata = base64encode(
-      templatefile("${path.root}/cloud-init--userdata.yml.tftpl", {
-        tf_hostname = "cluster-wkr-${count.index + 1}.mintworld.stg.${local.zone}"
-      })
-    )
-  }
 }
 
 resource "linode_instance_config" "stg_mintworld_cluster_wkr_config" {
@@ -96,7 +95,7 @@ resource "linode_instance_config" "stg_mintworld_cluster_wkr_config" {
     updatedb_disabled = true
   }
 
-  kernel = "linode/grub2"
+  kernel = "linode/latest-64bit"
   booted = true
 
   lifecycle {


### PR DESCRIPTION
This PR switches to use the latest kernels and userdata as metadata when creating Linodes moving away from stackscripts.
