### PR TITLE
chore: add editor config for Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,5 @@ trim_trailing_whitespace = false
 
 [makefile]
 indent_style = tab
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Two entries because TOML is case-insensitive