### PR TITLE
fix(api): increase stop grace period to 30s

### DIFF
--- a/docker/swarm/stacks/api/stack-api.yml
+++ b/docker/swarm/stacks/api/stack-api.yml
@@ -3,6 +3,7 @@ x-port-config: &port-config
   protocol: tcp
   mode: host
 x-deploy-config: &deploy-config
+  stop_grace_period: 30s
   deploy:
     replicas: 3
     update_config:


### PR DESCRIPTION
Default is 10s: https://docs.docker.com/reference/compose-file/services/#stop_grace_period

Needs to be larger than clean up in Fastify API server.