### PR TITLE
feat: r2alias cache control

### DIFF
--- a/caddy-r2alias/cache.go
+++ b/caddy-r2alias/cache.go
@@ -28,10 +28,10 @@ func newAliasCache(size int, ttl, fetchTimeout time.Duration) *aliasCache {
 		size = defaultCacheMaxEntries
 	}
 	if ttl <= 0 {
-		ttl = defaultCacheTTL
+		ttl = time.Duration(defaultCacheTTL)
 	}
 	if fetchTimeout <= 0 {
-		fetchTimeout = defaultFetchTimeout
+		fetchTimeout = time.Duration(defaultFetchTimeout)
 	}
 	return &aliasCache{
 		lru:          expirable.NewLRU[string, aliasEntry](size, nil, ttl),
@@ -58,8 +58,10 @@ func (c *aliasCache) Resolve(
 	key := cacheKey(bucket, site, aliasName)
 
 	if entry, ok := c.lru.Get(key); ok {
+		recordLookup(resultHit)
 		return entry, nil
 	}
+	recordLookup(resultMiss)
 
 	ch := c.sf.DoChan(key, func() (val any, err error) {
 		// A DoChan flight re-panics on a detached goroutine that no caller

--- a/caddy-r2alias/caddyfile.go
+++ b/caddy-r2alias/caddyfile.go
@@ -2,8 +2,8 @@ package r2alias
 
 import (
 	"strconv"
-	"time"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
@@ -70,20 +70,20 @@ func (r *R2Alias) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if !d.NextArg() {
 					return d.ArgErr()
 				}
-				dur, err := time.ParseDuration(d.Val())
+				dur, err := caddy.ParseDuration(d.Val())
 				if err != nil {
 					return d.Errf("cache_ttl: %v", err)
 				}
-				r.CacheTTL = dur
+				r.CacheTTL = caddy.Duration(dur)
 			case "fetch_timeout":
 				if !d.NextArg() {
 					return d.ArgErr()
 				}
-				dur, err := time.ParseDuration(d.Val())
+				dur, err := caddy.ParseDuration(d.Val())
 				if err != nil {
 					return d.Errf("fetch_timeout: %v", err)
 				}
-				r.FetchTimeout = dur
+				r.FetchTimeout = caddy.Duration(dur)
 			case "cache_max_entries":
 				if !d.NextArg() {
 					return d.ArgErr()

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -1,0 +1,93 @@
+package r2alias_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	_ "github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+)
+
+var chartConfigMap = filepath.Join("..", "k3s", "gxy-cassiopeia", "apps", "caddy",
+	"charts", "caddy", "templates", "configmap.yaml")
+
+func chartCaddyfile(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(chartConfigMap)
+	if err != nil {
+		t.Fatalf("read %s: %v", chartConfigMap, err)
+	}
+
+	lines := strings.Split(string(raw), "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "Caddyfile: |" {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("%s carries no `Caddyfile: |` block", chartConfigMap)
+	}
+
+	const indent = "    "
+	var block []string
+	for _, line := range lines[start:] {
+		if strings.TrimSpace(line) == "" {
+			block = append(block, "")
+			continue
+		}
+		if !strings.HasPrefix(line, indent) {
+			break
+		}
+		block = append(block, strings.TrimPrefix(line, indent))
+	}
+	return strings.Join(block, "\n")
+}
+
+func TestChartCaddyfileAdaptsUnderThisModuleSet(t *testing.T) {
+	for name, value := range map[string]string{
+		"R2_BUCKET":             "gxy-cassiopeia",
+		"R2_ENDPOINT":           "https://r2.example",
+		"AWS_ACCESS_KEY_ID":     "kid",
+		"AWS_SECRET_ACCESS_KEY": "sak",
+	} {
+		t.Setenv(name, value)
+	}
+
+	body := chartCaddyfile(t)
+	if !strings.Contains(body, "r2_alias") {
+		t.Fatalf("extracted block is not the site config: %q", body)
+	}
+
+	adapter := caddyconfig.GetAdapter("caddyfile")
+	if adapter == nil {
+		t.Fatal("no caddyfile adapter is registered")
+	}
+
+	_, warnings, err := adapter.Adapt([]byte(body), map[string]any{"filename": "Caddyfile"})
+	if err != nil {
+		t.Fatalf("the chart Caddyfile does not adapt, so this image would refuse to start: %v", err)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w.Message, "not formatted") {
+			continue
+		}
+		t.Errorf("adapt warning at %s:%d: %s", w.File, w.Line, w.Message)
+	}
+}
+
+func TestChartCaddyfileCarriesTheTestedCachePolicy(t *testing.T) {
+	t.Parallel()
+
+	body := chartCaddyfile(t)
+	if !strings.Contains(body, documentCacheControl) {
+		t.Errorf("the chart must send %q, the policy the integration tests prove", documentCacheControl)
+	}
+	if !strings.Contains(body, errorCacheControl) {
+		t.Errorf("the chart must send %q on an error, the policy the integration tests prove", errorCacheControl)
+	}
+}

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -129,7 +129,11 @@ func limitsMemoryMiB(t *testing.T, path, raw string) int {
 			if !ok {
 				continue
 			}
-			mib, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(value), "Mi"))
+			bare, ok := strings.CutSuffix(strings.TrimSpace(value), "Mi")
+			if !ok {
+				t.Fatalf("resources.limits.memory in %s must be written in Mi, got %q", path, value)
+			}
+			mib, err := strconv.Atoi(bare)
 			if err != nil {
 				t.Fatalf("parse resources.limits.memory in %s: %v", path, err)
 			}

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -106,6 +106,40 @@ func blockAfter(t *testing.T, body, opener string) string {
 	return ""
 }
 
+func indentOf(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " "))
+}
+
+func limitsMemoryMiB(t *testing.T, path, raw string) int {
+	t.Helper()
+
+	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "limits:" {
+			continue
+		}
+		for _, next := range lines[i+1:] {
+			if strings.TrimSpace(next) == "" {
+				continue
+			}
+			if indentOf(next) <= indentOf(line) {
+				break
+			}
+			value, ok := strings.CutPrefix(strings.TrimSpace(next), "memory:")
+			if !ok {
+				continue
+			}
+			mib, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(value), "Mi"))
+			if err != nil {
+				t.Fatalf("parse resources.limits.memory in %s: %v", path, err)
+			}
+			return mib
+		}
+	}
+	t.Fatalf("%s declares no resources.limits.memory", path)
+	return 0
+}
+
 func TestChartMemoryLimitsLeaveHeadroomForTheBudget(t *testing.T) {
 	t.Parallel()
 
@@ -133,15 +167,7 @@ func TestChartMemoryLimitsLeaveHeadroomForTheBudget(t *testing.T) {
 			t.Fatalf("read %s: %v", values, readErr)
 		}
 
-		limits := regexp.MustCompile(`(?m)^\s+limits:\n(?:\s+\w+:.*\n)*?\s+memory:\s*(\d+)Mi\s*$`).
-			FindStringSubmatch(string(raw))
-		if limits == nil {
-			t.Fatalf("%s declares no resources.limits.memory", values)
-		}
-		podMiB, convErr := strconv.Atoi(limits[1])
-		if convErr != nil {
-			t.Fatalf("parse memory limit in %s: %v", values, convErr)
-		}
+		podMiB := limitsMemoryMiB(t, values, string(raw))
 
 		soft := regexp.MustCompile(`(?m)^goMemLimit:\s*(\d+)MiB\s*$`).FindStringSubmatch(string(raw))
 		if soft == nil {

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -130,9 +130,16 @@ func TestChartCaddyfileCarriesTheTestedCachePolicy(t *testing.T) {
 	}
 
 	filesystem := blockAfter(t, body, "filesystem r2 r2 {")
-	if !strings.Contains(filesystem, "max_file_size     "+chartMaxFileSize) {
+	if !strings.Contains(filesystem, "max_file_size        "+chartMaxFileSize) {
 		t.Errorf("the chart must cap max_file_size at %s bytes; one in-flight fetch buffers that much per request",
 			chartMaxFileSize)
+	}
+	if !strings.Contains(filesystem, "max_in_flight_bytes  "+chartMaxInFlightBytes) {
+		t.Errorf("the chart must cap max_in_flight_bytes at %s bytes so the budget fits the pod limit",
+			chartMaxInFlightBytes)
+	}
+	if strings.Contains(body, "servers {") {
+		t.Error("the nested servers/metrics option is deprecated on caddy 2.11.3; use the global metrics option")
 	}
 
 	errors := blockAfter(t, body, "handle_errors {")

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -80,14 +80,48 @@ func TestChartCaddyfileAdaptsUnderThisModuleSet(t *testing.T) {
 	}
 }
 
+func blockAfter(t *testing.T, body, opener string) string {
+	t.Helper()
+
+	start := strings.Index(body, opener)
+	if start < 0 {
+		t.Fatalf("the chart Caddyfile has no %q block", opener)
+	}
+	rest := body[start+len(opener):]
+	depth := 1
+	for i, r := range rest {
+		switch r {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return rest[:i]
+			}
+		}
+	}
+	t.Fatalf("the %q block never closes", opener)
+	return ""
+}
+
 func TestChartCaddyfileCarriesTheTestedCachePolicy(t *testing.T) {
 	t.Parallel()
 
 	body := chartCaddyfile(t)
-	if !strings.Contains(body, documentCacheControl) {
-		t.Errorf("the chart must send %q, the policy the integration tests prove", documentCacheControl)
+
+	serving := blockAfter(t, body, "handle {")
+	if !strings.Contains(serving, `header Cache-Control "`+documentCacheControl+`"`) {
+		t.Errorf("the serving block must send %q, the policy the integration tests prove", documentCacheControl)
 	}
-	if !strings.Contains(body, errorCacheControl) {
-		t.Errorf("the chart must send %q on an error, the policy the integration tests prove", errorCacheControl)
+	if strings.Contains(serving, errorCacheControl) {
+		t.Errorf("the serving block must not send %q", errorCacheControl)
+	}
+
+	errors := blockAfter(t, body, "handle_errors {")
+	if !strings.Contains(errors, `header Cache-Control "`+errorCacheControl+`"`) {
+		t.Errorf("handle_errors must send %q, the policy the integration tests prove", errorCacheControl)
+	}
+	if strings.Contains(errors, documentCacheControl) {
+		t.Errorf("handle_errors must not send the serving policy %q", documentCacheControl)
 	}
 }

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -117,6 +117,18 @@ func TestChartCaddyfileCarriesTheTestedCachePolicy(t *testing.T) {
 		t.Errorf("the serving block must not send %q", errorCacheControl)
 	}
 
+	if !strings.Contains(body, ":"+chartMetricsPort+" {") {
+		t.Errorf("the chart must expose the metrics listener on :%s", chartMetricsPort)
+	}
+	values, err := os.ReadFile(filepath.Join("..", "k3s", "gxy-cassiopeia", "apps", "caddy",
+		"charts", "caddy", "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	if !strings.Contains(string(values), "port: "+chartMetricsPort) {
+		t.Errorf("values.yaml must publish the same metrics port %s as the Caddyfile", chartMetricsPort)
+	}
+
 	filesystem := blockAfter(t, body, "filesystem r2 r2 {")
 	if !strings.Contains(filesystem, "max_file_size     "+chartMaxFileSize) {
 		t.Errorf("the chart must cap max_file_size at %s bytes; one in-flight fetch buffers that much per request",

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -3,6 +3,8 @@ package r2alias_test
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -102,6 +104,53 @@ func blockAfter(t *testing.T, body, opener string) string {
 	}
 	t.Fatalf("the %q block never closes", opener)
 	return ""
+}
+
+func TestChartMemoryLimitsLeaveHeadroomForTheBudget(t *testing.T) {
+	t.Parallel()
+
+	inFlightMiB, err := strconv.Atoi(chartMaxInFlightBytes)
+	if err != nil {
+		t.Fatalf("parse %s: %v", chartMaxInFlightBytes, err)
+	}
+	inFlightMiB /= 1024 * 1024
+
+	for _, values := range []string{
+		filepath.Join("..", "k3s", "gxy-cassiopeia", "apps", "caddy", "charts", "caddy", "values.yaml"),
+		filepath.Join("..", "k3s", "gxy-cassiopeia", "apps", "caddy", "values.production.yaml"),
+	} {
+		raw, readErr := os.ReadFile(values)
+		if readErr != nil {
+			t.Fatalf("read %s: %v", values, readErr)
+		}
+
+		limits := regexp.MustCompile(`(?m)^\s+memory:\s*(\d+)Mi\s*$`).FindAllStringSubmatch(string(raw), -1)
+		if len(limits) == 0 {
+			t.Fatalf("%s declares no memory limit", values)
+		}
+		podMiB, convErr := strconv.Atoi(limits[len(limits)-1][1])
+		if convErr != nil {
+			t.Fatalf("parse memory limit in %s: %v", values, convErr)
+		}
+
+		soft := regexp.MustCompile(`(?m)^goMemLimit:\s*(\d+)MiB\s*$`).FindStringSubmatch(string(raw))
+		if soft == nil {
+			t.Fatalf("%s sets no goMemLimit, so the soft limit never engages", values)
+		}
+		softMiB, convErr := strconv.Atoi(soft[1])
+		if convErr != nil {
+			t.Fatalf("parse goMemLimit in %s: %v", values, convErr)
+		}
+
+		if softMiB >= podMiB {
+			t.Errorf("%s: goMemLimit %dMiB must sit below the pod limit %dMi or it never engages",
+				values, softMiB, podMiB)
+		}
+		if softMiB <= inFlightMiB {
+			t.Errorf("%s: goMemLimit %dMiB must exceed the %dMiB in-flight budget",
+				values, softMiB, inFlightMiB)
+		}
+	}
 }
 
 func TestChartCaddyfileCarriesTheTestedCachePolicy(t *testing.T) {

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -117,6 +117,12 @@ func TestChartCaddyfileCarriesTheTestedCachePolicy(t *testing.T) {
 		t.Errorf("the serving block must not send %q", errorCacheControl)
 	}
 
+	filesystem := blockAfter(t, body, "filesystem r2 r2 {")
+	if !strings.Contains(filesystem, "max_file_size     "+chartMaxFileSize) {
+		t.Errorf("the chart must cap max_file_size at %s bytes; one in-flight fetch buffers that much per request",
+			chartMaxFileSize)
+	}
+
 	errors := blockAfter(t, body, "handle_errors {")
 	if !strings.Contains(errors, `header Cache-Control "`+errorCacheControl+`"`) {
 		t.Errorf("handle_errors must send %q, the policy the integration tests prove", errorCacheControl)

--- a/caddy-r2alias/chart_caddyfile_test.go
+++ b/caddy-r2alias/chart_caddyfile_test.go
@@ -115,6 +115,15 @@ func TestChartMemoryLimitsLeaveHeadroomForTheBudget(t *testing.T) {
 	}
 	inFlightMiB /= 1024 * 1024
 
+	deployment, err := os.ReadFile(filepath.Join("..", "k3s", "gxy-cassiopeia", "apps", "caddy",
+		"charts", "caddy", "templates", "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("read deployment.yaml: %v", err)
+	}
+	if !regexp.MustCompile(`name:\s*GOMEMLIMIT\n\s+value:\s*\{\{\s*\.Values\.goMemLimit`).Match(deployment) {
+		t.Error("the Deployment must wire .Values.goMemLimit into GOMEMLIMIT, or the soft limit never reaches the pod")
+	}
+
 	for _, values := range []string{
 		filepath.Join("..", "k3s", "gxy-cassiopeia", "apps", "caddy", "charts", "caddy", "values.yaml"),
 		filepath.Join("..", "k3s", "gxy-cassiopeia", "apps", "caddy", "values.production.yaml"),
@@ -124,11 +133,12 @@ func TestChartMemoryLimitsLeaveHeadroomForTheBudget(t *testing.T) {
 			t.Fatalf("read %s: %v", values, readErr)
 		}
 
-		limits := regexp.MustCompile(`(?m)^\s+memory:\s*(\d+)Mi\s*$`).FindAllStringSubmatch(string(raw), -1)
-		if len(limits) == 0 {
-			t.Fatalf("%s declares no memory limit", values)
+		limits := regexp.MustCompile(`(?m)^\s+limits:\n(?:\s+\w+:.*\n)*?\s+memory:\s*(\d+)Mi\s*$`).
+			FindStringSubmatch(string(raw))
+		if limits == nil {
+			t.Fatalf("%s declares no resources.limits.memory", values)
 		}
-		podMiB, convErr := strconv.Atoi(limits[len(limits)-1][1])
+		podMiB, convErr := strconv.Atoi(limits[1])
 		if convErr != nil {
 			t.Fatalf("parse memory limit in %s: %v", values, convErr)
 		}

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -565,14 +565,14 @@ func (r *R2FS) reweighBudget(held, actual int64) (int64, error) {
 		r.releaseBudget(held - actual)
 		return actual, nil
 	}
-	if r.budget == nil || r.budget.TryAcquire(actual-held) {
+	r.releaseBudget(held)
+	if r.budget == nil {
 		return actual, nil
 	}
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), budgetGrowWait)
 	defer cancel()
-	if err := r.budget.Acquire(waitCtx, actual-held); err != nil {
-		r.releaseBudget(held)
+	if err := r.budget.Acquire(waitCtx, actual); err != nil {
 		return 0, fmt.Errorf("caddy.fs.r2: in-flight budget exhausted for %d delivered bytes", actual)
 	}
 	return actual, nil

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -36,6 +36,8 @@ const opTimeout = 30 * time.Second
 // so one HeadObject against that key fully decides the directory question.
 const indexFile = "index.html"
 
+var errObjectTooLarge = errors.New("caddy.fs.r2: object exceeds max_file_size")
+
 // R2FS is a Caddy filesystem module (caddy.fs.r2) that serves objects from
 // an S3-compatible bucket.
 type R2FS struct {
@@ -222,7 +224,8 @@ func (r *R2FS) Open(name string) (fs.File, error) {
 		}, nil
 	}
 	if !errors.Is(err, fs.ErrNotExist) {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+		r.logger.Error("r2 head failed", zap.String("path", name), zap.Error(err))
+		return nil, fmt.Errorf("caddy.fs.r2: open %s: %w", name, err)
 	}
 
 	if r.indexProbe != nil {
@@ -230,7 +233,7 @@ func (r *R2FS) Open(name string) (fs.File, error) {
 		if probeErr != nil {
 			r.logger.Warn("r2 index probe failed",
 				zap.String("path", name), zap.Error(probeErr))
-			return nil, &fs.PathError{Op: "open", Path: name, Err: probeErr}
+			return nil, fmt.Errorf("caddy.fs.r2: index probe %s: %w", name, probeErr)
 		}
 		if has {
 			r.logger.Debug("r2 virtual directory", zap.String("path", name))
@@ -239,6 +242,7 @@ func (r *R2FS) Open(name string) (fs.File, error) {
 					name:  path.Base(name),
 					isDir: true,
 				},
+				reader: bytes.NewReader(nil),
 			}, nil
 		}
 	}
@@ -327,13 +331,17 @@ func (r *R2FS) getObject(ctx context.Context, key string) (*r2Object, error) {
 	defer func() { _ = out.Body.Close() }()
 
 	if out.ContentLength != nil && *out.ContentLength > r.MaxFileSize {
-		return nil, fmt.Errorf("caddy.fs.r2: object %s size %d exceeds max_file_size %d",
-			key, *out.ContentLength, r.MaxFileSize)
+		return nil, fmt.Errorf("%w: %s declares %d bytes, limit %d",
+			errObjectTooLarge, key, *out.ContentLength, r.MaxFileSize)
 	}
 
-	body, readErr := io.ReadAll(io.LimitReader(out.Body, r.MaxFileSize))
+	body, readErr := io.ReadAll(io.LimitReader(out.Body, r.MaxFileSize+1))
 	if readErr != nil {
 		return nil, fmt.Errorf("caddy.fs.r2: read body %s: %w", key, readErr)
+	}
+	if int64(len(body)) > r.MaxFileSize {
+		return nil, fmt.Errorf("%w: %s streamed past the %d byte limit",
+			errObjectTooLarge, key, r.MaxFileSize)
 	}
 
 	var modTime time.Time
@@ -385,7 +393,6 @@ type r2File struct {
 	info   *r2FileInfo
 	load   func() ([]byte, error)
 	reader *bytes.Reader
-	offset int64
 }
 
 func (f *r2File) body() (*bytes.Reader, error) {
@@ -399,17 +406,7 @@ func (f *r2File) body() (*bytes.Reader, error) {
 			return nil, err
 		}
 	}
-	// A HeadObject size that disagrees with the GetObject body means the object
-	// changed between the two calls. ServeContent has already sent the HEAD size
-	// as Content-Length, so fail the read rather than silently under-deliver.
-	if f.load != nil && int64(len(raw)) != f.info.size {
-		return nil, fmt.Errorf("caddy.fs.r2: body %d bytes, HeadObject declared %d",
-			len(raw), f.info.size)
-	}
 	f.reader = bytes.NewReader(raw)
-	if _, err := f.reader.Seek(f.offset, io.SeekStart); err != nil {
-		return nil, err
-	}
 	return f.reader, nil
 }
 
@@ -420,34 +417,15 @@ func (f *r2File) Read(p []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	n, readErr := reader.Read(p)
-	f.offset += int64(n)
-	return n, readErr
+	return reader.Read(p)
 }
 
 func (f *r2File) Seek(offset int64, whence int) (int64, error) {
-	if f.reader != nil {
-		pos, err := f.reader.Seek(offset, whence)
-		f.offset = pos
-		return pos, err
+	reader, err := f.body()
+	if err != nil {
+		return 0, err
 	}
-
-	var abs int64
-	switch whence {
-	case io.SeekStart:
-		abs = offset
-	case io.SeekCurrent:
-		abs = f.offset + offset
-	case io.SeekEnd:
-		abs = f.info.size + offset
-	default:
-		return 0, fs.ErrInvalid
-	}
-	if abs < 0 {
-		return 0, fs.ErrInvalid
-	}
-	f.offset = abs
-	return abs, nil
+	return reader.Seek(offset, whence)
 }
 
 func (f *r2File) ReadAt(p []byte, off int64) (int, error) {

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -105,19 +105,22 @@ func (r *R2FS) applyDefaults() {
 	if r.MaxInFlightBytes <= 0 {
 		r.MaxInFlightBytes = defaultMaxInFlightBytes
 	}
-	if r.MaxInFlightBytes < r.MaxFileSize {
-		r.MaxInFlightBytes = r.MaxFileSize
-	}
 }
 
 func (r *R2FS) Provision(ctx caddy.Context) error {
 	r.applyDefaults()
 	r.logger = ctx.Logger()
-	initMetrics(ctx.GetMetricsRegistry())
+	if err := initMetrics(ctx.GetMetricsRegistry()); err != nil {
+		return fmt.Errorf("caddy.fs.r2: %w", err)
+	}
 
-	if err := resolvePlaceholders(
-		&r.Bucket, &r.Endpoint, &r.Region, &r.AccessKeyID, &r.SecretAccessKey,
-	); err != nil {
+	if err := resolvePlaceholders(map[string]*string{
+		"bucket":            &r.Bucket,
+		"endpoint":          &r.Endpoint,
+		"region":            &r.Region,
+		"access_key_id":     &r.AccessKeyID,
+		"secret_access_key": &r.SecretAccessKey,
+	}); err != nil {
 		return fmt.Errorf("caddy.fs.r2: %w", err)
 	}
 
@@ -298,8 +301,15 @@ func (r *R2FS) Open(name string) (fs.File, error) {
 				return nil, ferr
 			}
 
-			addBufferedBytes(float64(weight))
-			file.release = func() { r.releaseBudget(weight); addBufferedBytes(-float64(weight)) }
+			held, ferr := r.reweighBudget(loadCtx, weight, int64(len(obj.Body)))
+			if ferr != nil {
+				r.logger.Error("r2 in-flight budget exhausted",
+					zap.String("path", name), zap.Int64("bytes", int64(len(obj.Body))), zap.Error(ferr))
+				return nil, ferr
+			}
+
+			addBufferedBytes(float64(held))
+			file.release = func() { r.releaseBudget(held); addBufferedBytes(-float64(held)) }
 			return obj.Body, nil
 		}
 		return file, nil
@@ -540,6 +550,22 @@ func (r *R2FS) acquireBudget(ctx context.Context, weight int64) error {
 		return fmt.Errorf("caddy.fs.r2: in-flight budget exhausted: %w", err)
 	}
 	return nil
+}
+
+func (r *R2FS) reweighBudget(ctx context.Context, held, actual int64) (int64, error) {
+	if actual < 1 {
+		actual = 1
+	}
+	switch {
+	case actual > held:
+		if err := r.acquireBudget(ctx, actual-held); err != nil {
+			r.releaseBudget(held)
+			return 0, err
+		}
+	case actual < held:
+		r.releaseBudget(held - actual)
+	}
+	return actual, nil
 }
 
 func (r *R2FS) releaseBudget(weight int64) {

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -242,7 +242,6 @@ func (r *R2FS) Open(name string) (fs.File, error) {
 					name:  path.Base(name),
 					isDir: true,
 				},
-				reader: bytes.NewReader(nil),
 			}, nil
 		}
 	}
@@ -267,7 +266,7 @@ func (r *R2FS) Stat(name string) (fs.FileInfo, error) {
 		}, nil
 	}
 	if !errors.Is(err, fs.ErrNotExist) {
-		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
+		return nil, fmt.Errorf("caddy.fs.r2: stat %s: %w", name, err)
 	}
 
 	if r.indexProbe != nil {
@@ -275,7 +274,7 @@ func (r *R2FS) Stat(name string) (fs.FileInfo, error) {
 		if probeErr != nil {
 			r.logger.Warn("r2 index probe failed",
 				zap.String("path", name), zap.Error(probeErr))
-			return nil, &fs.PathError{Op: "stat", Path: name, Err: probeErr}
+			return nil, fmt.Errorf("caddy.fs.r2: stat index probe %s: %w", name, probeErr)
 		}
 		if has {
 			return &r2FileInfo{name: path.Base(name), isDir: true}, nil

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -32,6 +32,8 @@ const objectRetryAttempts = 2
 
 const objectRetryMaxBackoff = 500 * time.Millisecond
 
+const budgetGrowWait = 250 * time.Millisecond
+
 // opTimeout bounds every S3 round-trip from Open. fs.FS has no context
 // parameter, so the ceiling is enforced here rather than by the caller.
 const opTimeout = 30 * time.Second
@@ -563,7 +565,13 @@ func (r *R2FS) reweighBudget(held, actual int64) (int64, error) {
 		r.releaseBudget(held - actual)
 		return actual, nil
 	}
-	if r.budget != nil && !r.budget.TryAcquire(actual-held) {
+	if r.budget == nil || r.budget.TryAcquire(actual-held) {
+		return actual, nil
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), budgetGrowWait)
+	defer cancel()
+	if err := r.budget.Acquire(waitCtx, actual-held); err != nil {
 		r.releaseBudget(held)
 		return 0, fmt.Errorf("caddy.fs.r2: in-flight budget exhausted for %d delivered bytes", actual)
 	}

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -13,19 +13,24 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"go.uber.org/zap"
+	"golang.org/x/sync/semaphore"
 )
 
 // defaultMaxFileSize caps the in-memory buffer for any single object.
 // Larger objects return fs.ErrInvalid from Open — ship them out of band
 // rather than streaming through a static-serving cluster.
 const defaultMaxFileSize int64 = 100 * 1024 * 1024
+
+const defaultMaxInFlightBytes int64 = 256 * 1024 * 1024
+
+const objectRetryAttempts = 2
+
+const objectRetryMaxBackoff = 500 * time.Millisecond
 
 // opTimeout bounds every S3 round-trip from Open. fs.FS has no context
 // parameter, so the ceiling is enforced here rather than by the caller.
@@ -41,16 +46,19 @@ var errObjectTooLarge = errors.New("caddy.fs.r2: object exceeds max_file_size")
 // R2FS is a Caddy filesystem module (caddy.fs.r2) that serves objects from
 // an S3-compatible bucket.
 type R2FS struct {
-	Bucket          string `json:"bucket"`
-	Endpoint        string `json:"endpoint"`
-	Region          string `json:"region"`
-	AccessKeyID     string `json:"access_key_id,omitempty"`
-	SecretAccessKey string `json:"secret_access_key,omitempty"`
-	UsePathStyle    bool   `json:"use_path_style,omitempty"`
-	MaxFileSize     int64  `json:"max_file_size,omitempty"`
+	Bucket           string `json:"bucket"`
+	Endpoint         string `json:"endpoint"`
+	Region           string `json:"region"`
+	AccessKeyID      string `json:"access_key_id,omitempty"`
+	SecretAccessKey  string `json:"secret_access_key,omitempty"`
+	UsePathStyle     *bool  `json:"use_path_style,omitempty"`
+	MaxFileSize      int64  `json:"max_file_size,omitempty"`
+	MaxInFlightBytes int64  `json:"max_in_flight_bytes,omitempty"`
 
-	client *s3.Client
-	logger *zap.Logger
+	client    *s3.Client
+	clientKey string
+	budget    *semaphore.Weighted
+	logger    *zap.Logger
 
 	// fetcher is the GetObject path. Provision wires it to r.getObject;
 	// tests swap in a stub so Open/Stat run without an S3 client.
@@ -83,35 +91,52 @@ func (R2FS) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-func (r *R2FS) Provision(ctx caddy.Context) error {
-	if r.Bucket == "" {
-		return fmt.Errorf("caddy.fs.r2: bucket is required")
-	}
-	if r.Endpoint == "" {
-		return fmt.Errorf("caddy.fs.r2: endpoint is required")
-	}
+func (r *R2FS) applyDefaults() {
 	if r.Region == "" {
 		r.Region = defaultRegion
+	}
+	if r.UsePathStyle == nil {
+		pathStyle := true
+		r.UsePathStyle = &pathStyle
 	}
 	if r.MaxFileSize <= 0 {
 		r.MaxFileSize = defaultMaxFileSize
 	}
+	if r.MaxInFlightBytes <= 0 {
+		r.MaxInFlightBytes = defaultMaxInFlightBytes
+	}
+	if r.MaxInFlightBytes < r.MaxFileSize {
+		r.MaxInFlightBytes = r.MaxFileSize
+	}
+}
 
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(r.Region),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			r.AccessKeyID, r.SecretAccessKey, "",
-		)),
-	)
+func (r *R2FS) Provision(ctx caddy.Context) error {
+	r.applyDefaults()
+	r.logger = ctx.Logger()
+	initMetrics(ctx.GetMetricsRegistry())
+
+	if err := resolvePlaceholders(
+		&r.Bucket, &r.Endpoint, &r.Region, &r.AccessKeyID, &r.SecretAccessKey,
+	); err != nil {
+		return fmt.Errorf("caddy.fs.r2: %w", err)
+	}
+
+	client, clientKey, err := sharedS3Client(ctx, r2ClientConfig{
+		Bucket:          r.Bucket,
+		Endpoint:        r.Endpoint,
+		Region:          r.Region,
+		AccessKeyID:     r.AccessKeyID,
+		SecretAccessKey: r.SecretAccessKey,
+		UsePathStyle:    *r.UsePathStyle,
+		MaxAttempts:     objectRetryAttempts,
+		MaxBackoff:      objectRetryMaxBackoff,
+	}, r.logger)
 	if err != nil {
 		return fmt.Errorf("caddy.fs.r2: load aws config: %w", err)
 	}
-	r.client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
-		o.BaseEndpoint = aws.String(r.Endpoint)
-		// R2 requires path-style; bucket-in-hostname would break the target.
-		o.UsePathStyle = true
-	})
-	r.logger = ctx.Logger()
+	r.client, r.clientKey = client, clientKey
+	r.budget = semaphore.NewWeighted(r.MaxInFlightBytes)
+
 	if r.fetcher == nil {
 		r.fetcher = r.getObject
 	}
@@ -122,6 +147,29 @@ func (r *R2FS) Provision(ctx caddy.Context) error {
 		r.indexProbe = r.hasIndex
 	}
 	return nil
+}
+
+func (r *R2FS) Validate() error {
+	if r.Bucket == "" {
+		return fmt.Errorf("caddy.fs.r2: bucket is required")
+	}
+	if r.Endpoint == "" {
+		return fmt.Errorf("caddy.fs.r2: endpoint is required")
+	}
+	r.applyDefaults()
+	if r.MaxInFlightBytes < r.MaxFileSize {
+		return fmt.Errorf("caddy.fs.r2: max_in_flight_bytes %d is below max_file_size %d",
+			r.MaxInFlightBytes, r.MaxFileSize)
+	}
+	return nil
+}
+
+func (r *R2FS) Cleanup() error {
+	if r.clientKey == "" {
+		return nil
+	}
+	_, err := s3Clients.Delete(r.clientKey)
+	return err
 }
 
 // UnmarshalCaddyfile parses:
@@ -168,7 +216,15 @@ func (r *R2FS) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				r.SecretAccessKey = d.Val()
 			case "use_path_style":
-				r.UsePathStyle = true
+				pathStyle := true
+				if d.NextArg() {
+					parsed, err := strconv.ParseBool(d.Val())
+					if err != nil {
+						return d.Errf("use_path_style: %v", err)
+					}
+					pathStyle = parsed
+				}
+				r.UsePathStyle = &pathStyle
 			case "max_file_size":
 				if !d.NextArg() {
 					return d.ArgErr()
@@ -178,6 +234,15 @@ func (r *R2FS) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Errf("max_file_size: %v", err)
 				}
 				r.MaxFileSize = n
+			case "max_in_flight_bytes":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				n, err := strconv.ParseInt(d.Val(), 10, 64)
+				if err != nil {
+					return d.Errf("max_in_flight_bytes: %v", err)
+				}
+				r.MaxInFlightBytes = n
 			default:
 				return d.Errf("unknown caddy.fs.r2 sub-directive: %s", d.Val())
 			}
@@ -204,24 +269,40 @@ func (r *R2FS) Open(name string) (fs.File, error) {
 				zap.String("path", name), zap.Int64("size", head.Size))
 			return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 		}
-		return &r2File{
+		file := &r2File{
 			info: &r2FileInfo{
 				name:    path.Base(name),
 				size:    head.Size,
 				modTime: head.LastModified,
 			},
-			load: func() ([]byte, error) {
-				loadCtx, loadCancel := context.WithTimeout(context.Background(), opTimeout)
-				defer loadCancel()
-				obj, ferr := r.fetcher(loadCtx, name)
-				if ferr != nil {
-					r.logger.Error("r2 body fetch failed",
-						zap.String("path", name), zap.Error(ferr))
-					return nil, ferr
-				}
-				return obj.Body, nil
-			},
-		}, nil
+		}
+		file.load = func() ([]byte, error) {
+			loadCtx, loadCancel := context.WithTimeout(context.Background(), opTimeout)
+			defer loadCancel()
+
+			weight := head.Size
+			if weight < 1 {
+				weight = 1
+			}
+			if err := r.acquireBudget(loadCtx, weight); err != nil {
+				r.logger.Error("r2 in-flight budget exhausted",
+					zap.String("path", name), zap.Int64("bytes", weight), zap.Error(err))
+				return nil, err
+			}
+
+			obj, ferr := r.fetcher(loadCtx, name)
+			if ferr != nil {
+				r.releaseBudget(weight)
+				r.logger.Error("r2 body fetch failed",
+					zap.String("path", name), zap.Error(ferr))
+				return nil, ferr
+			}
+
+			addBufferedBytes(float64(weight))
+			file.release = func() { r.releaseBudget(weight); addBufferedBytes(-float64(weight)) }
+			return obj.Body, nil
+		}
+		return file, nil
 	}
 	if !errors.Is(err, fs.ErrNotExist) {
 		r.logger.Error("r2 head failed", zap.String("path", name), zap.Error(err))
@@ -290,14 +371,16 @@ func (r *R2FS) headObject(ctx context.Context, key string) (*r2Object, error) {
 	})
 	if err != nil {
 		if isNoSuchKey(err) {
+			recordOperation(opHead, resultNotFound)
 			return nil, fmt.Errorf("caddy.fs.r2: %w", fs.ErrNotExist)
 		}
-		var respErr *awshttp.ResponseError
-		if errors.As(err, &respErr) && respErr.HTTPStatusCode() >= 500 {
-			return nil, fmt.Errorf("caddy.fs.r2: upstream 5xx: %w", err)
+		recordOperation(opHead, resultError)
+		if code, upstream := upstreamStatus(err); upstream {
+			return nil, fmt.Errorf("caddy.fs.r2: upstream %d: %w", code, err)
 		}
 		return nil, fmt.Errorf("caddy.fs.r2: HeadObject %s: %w", key, err)
 	}
+	recordOperation(opHead, resultOK)
 
 	obj := &r2Object{}
 	if out.ContentLength != nil {
@@ -319,29 +402,34 @@ func (r *R2FS) getObject(ctx context.Context, key string) (*r2Object, error) {
 	})
 	if err != nil {
 		if isNoSuchKey(err) {
+			recordOperation(opGet, resultNotFound)
 			return nil, fmt.Errorf("caddy.fs.r2: %w", fs.ErrNotExist)
 		}
-		var respErr *awshttp.ResponseError
-		if errors.As(err, &respErr) && respErr.HTTPStatusCode() >= 500 {
-			return nil, fmt.Errorf("caddy.fs.r2: upstream 5xx: %w", err)
+		recordOperation(opGet, resultError)
+		if code, upstream := upstreamStatus(err); upstream {
+			return nil, fmt.Errorf("caddy.fs.r2: upstream %d: %w", code, err)
 		}
 		return nil, fmt.Errorf("caddy.fs.r2: GetObject %s: %w", key, err)
 	}
 	defer func() { _ = out.Body.Close() }()
 
 	if out.ContentLength != nil && *out.ContentLength > r.MaxFileSize {
+		recordOperation(opGet, resultTooLarge)
 		return nil, fmt.Errorf("%w: %s declares %d bytes, limit %d",
 			errObjectTooLarge, key, *out.ContentLength, r.MaxFileSize)
 	}
 
 	body, readErr := io.ReadAll(io.LimitReader(out.Body, r.MaxFileSize+1))
 	if readErr != nil {
+		recordOperation(opGet, resultError)
 		return nil, fmt.Errorf("caddy.fs.r2: read body %s: %w", key, readErr)
 	}
 	if int64(len(body)) > r.MaxFileSize {
+		recordOperation(opGet, resultTooLarge)
 		return nil, fmt.Errorf("%w: %s streamed past the %d byte limit",
 			errObjectTooLarge, key, r.MaxFileSize)
 	}
+	recordOperation(opGet, resultOK)
 
 	var modTime time.Time
 	if out.LastModified != nil {
@@ -389,9 +477,10 @@ func isNoSuchKey(err error) bool {
 }
 
 type r2File struct {
-	info   *r2FileInfo
-	load   func() ([]byte, error)
-	reader *bytes.Reader
+	info    *r2FileInfo
+	load    func() ([]byte, error)
+	release func()
+	reader  *bytes.Reader
 }
 
 func (f *r2File) body() (*bytes.Reader, error) {
@@ -435,7 +524,29 @@ func (f *r2File) ReadAt(p []byte, off int64) (int, error) {
 	return reader.ReadAt(p, off)
 }
 
-func (f *r2File) Close() error { return nil }
+func (f *r2File) Close() error {
+	if f.release != nil {
+		f.release()
+		f.release = nil
+	}
+	return nil
+}
+
+func (r *R2FS) acquireBudget(ctx context.Context, weight int64) error {
+	if r.budget == nil {
+		return nil
+	}
+	if err := r.budget.Acquire(ctx, weight); err != nil {
+		return fmt.Errorf("caddy.fs.r2: in-flight budget exhausted: %w", err)
+	}
+	return nil
+}
+
+func (r *R2FS) releaseBudget(weight int64) {
+	if r.budget != nil {
+		r.budget.Release(weight)
+	}
+}
 
 type r2FileInfo struct {
 	name    string

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -556,11 +556,15 @@ func (r *R2FS) reweighBudget(held, actual int64) (int64, error) {
 	if actual < 1 {
 		actual = 1
 	}
-	if actual == held {
+	switch {
+	case actual == held:
 		return held, nil
+	case actual < held:
+		r.releaseBudget(held - actual)
+		return actual, nil
 	}
-	r.releaseBudget(held)
-	if r.budget != nil && !r.budget.TryAcquire(actual) {
+	if r.budget != nil && !r.budget.TryAcquire(actual-held) {
+		r.releaseBudget(held)
 		return 0, fmt.Errorf("caddy.fs.r2: in-flight budget exhausted for %d delivered bytes", actual)
 	}
 	return actual, nil

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -301,7 +301,7 @@ func (r *R2FS) Open(name string) (fs.File, error) {
 				return nil, ferr
 			}
 
-			held, ferr := r.reweighBudget(loadCtx, weight, int64(len(obj.Body)))
+			held, ferr := r.reweighBudget(weight, int64(len(obj.Body)))
 			if ferr != nil {
 				r.logger.Error("r2 in-flight budget exhausted",
 					zap.String("path", name), zap.Int64("bytes", int64(len(obj.Body))), zap.Error(ferr))
@@ -552,18 +552,16 @@ func (r *R2FS) acquireBudget(ctx context.Context, weight int64) error {
 	return nil
 }
 
-func (r *R2FS) reweighBudget(ctx context.Context, held, actual int64) (int64, error) {
+func (r *R2FS) reweighBudget(held, actual int64) (int64, error) {
 	if actual < 1 {
 		actual = 1
 	}
-	switch {
-	case actual > held:
-		if err := r.acquireBudget(ctx, actual-held); err != nil {
-			r.releaseBudget(held)
-			return 0, err
-		}
-	case actual < held:
-		r.releaseBudget(held - actual)
+	if actual == held {
+		return held, nil
+	}
+	r.releaseBudget(held)
+	if r.budget != nil && !r.budget.TryAcquire(actual) {
+		return 0, fmt.Errorf("caddy.fs.r2: in-flight budget exhausted for %d delivered bytes", actual)
 	}
 	return actual, nil
 }

--- a/caddy-r2alias/filesystem.go
+++ b/caddy-r2alias/filesystem.go
@@ -34,6 +34,8 @@ const objectRetryMaxBackoff = 500 * time.Millisecond
 
 const budgetGrowWait = 250 * time.Millisecond
 
+const maxConcurrentGrowWaits = 4
+
 // opTimeout bounds every S3 round-trip from Open. fs.FS has no context
 // parameter, so the ceiling is enforced here rather than by the caller.
 const opTimeout = 30 * time.Second
@@ -60,6 +62,7 @@ type R2FS struct {
 	client    *s3.Client
 	clientKey string
 	budget    *semaphore.Weighted
+	growWaits *semaphore.Weighted
 	logger    *zap.Logger
 
 	// fetcher is the GetObject path. Provision wires it to r.getObject;
@@ -141,6 +144,7 @@ func (r *R2FS) Provision(ctx caddy.Context) error {
 	}
 	r.client, r.clientKey = client, clientKey
 	r.budget = semaphore.NewWeighted(r.MaxInFlightBytes)
+	r.growWaits = semaphore.NewWeighted(maxConcurrentGrowWaits)
 
 	if r.fetcher == nil {
 		r.fetcher = r.getObject
@@ -569,6 +573,18 @@ func (r *R2FS) reweighBudget(held, actual int64) (int64, error) {
 	if r.budget == nil {
 		return actual, nil
 	}
+	if r.budget.TryAcquire(actual) {
+		return actual, nil
+	}
+
+	if r.growWaits != nil && !r.growWaits.TryAcquire(1) {
+		return 0, fmt.Errorf("caddy.fs.r2: too many bodies already waiting to be charged")
+	}
+	defer func() {
+		if r.growWaits != nil {
+			r.growWaits.Release(1)
+		}
+	}()
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), budgetGrowWait)
 	defer cancel()

--- a/caddy-r2alias/filesystem_test.go
+++ b/caddy-r2alias/filesystem_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"go.uber.org/zap"
+	"golang.org/x/sync/semaphore"
 )
 
 // Tests assign r.fetcher to control how Open resolves S3 GetObject. No AWS
@@ -21,6 +22,7 @@ func newTestR2FS() *R2FS {
 		Endpoint:    "https://r2.example",
 		Region:      "auto",
 		MaxFileSize: defaultMaxFileSize,
+		growWaits:   semaphore.NewWeighted(maxConcurrentGrowWaits),
 		logger:      zap.NewNop(),
 	}
 	r.header = func(ctx context.Context, key string) (*r2Object, error) {

--- a/caddy-r2alias/filesystem_test.go
+++ b/caddy-r2alias/filesystem_test.go
@@ -215,7 +215,8 @@ func TestR2FS_UnmarshalCaddyfile_FullBlock(t *testing.T) {
 func TestR2FS_UnmarshalCaddyfile_MissingArgument(t *testing.T) {
 	t.Parallel()
 	for _, directive := range []string{
-		"bucket", "endpoint", "region", "access_key_id", "secret_access_key", "max_file_size",
+		"bucket", "endpoint", "region", "access_key_id", "secret_access_key",
+		"max_file_size", "max_in_flight_bytes",
 	} {
 		t.Run(directive, func(t *testing.T) {
 			t.Parallel()

--- a/caddy-r2alias/filesystem_test.go
+++ b/caddy-r2alias/filesystem_test.go
@@ -204,7 +204,7 @@ func TestR2FS_UnmarshalCaddyfile_FullBlock(t *testing.T) {
 	if r.AccessKeyID != "kid" || r.SecretAccessKey != "sak" {
 		t.Errorf("creds: %+v", r)
 	}
-	if !r.UsePathStyle {
+	if r.UsePathStyle == nil || !*r.UsePathStyle {
 		t.Errorf("UsePathStyle should be true after flag")
 	}
 	if r.MaxFileSize != 50_000_000 {

--- a/caddy-r2alias/filesystem_test.go
+++ b/caddy-r2alias/filesystem_test.go
@@ -212,6 +212,38 @@ func TestR2FS_UnmarshalCaddyfile_FullBlock(t *testing.T) {
 	}
 }
 
+func TestR2FS_UnmarshalCaddyfile_MissingArgument(t *testing.T) {
+	t.Parallel()
+	for _, directive := range []string{
+		"bucket", "endpoint", "region", "access_key_id", "secret_access_key", "max_file_size",
+	} {
+		t.Run(directive, func(t *testing.T) {
+			t.Parallel()
+			d := caddyfile.NewTestDispenser("r2 {\n\t" + directive + "\n}")
+			if err := new(R2FS).UnmarshalCaddyfile(d); err == nil {
+				t.Fatalf("%s with no argument must not parse", directive)
+			}
+		})
+	}
+}
+
+func TestR2FS_UnmarshalCaddyfile_RejectsAnInlineArgument(t *testing.T) {
+	t.Parallel()
+	d := caddyfile.NewTestDispenser("r2 unexpected {\n\tbucket foo\n}")
+	if err := new(R2FS).UnmarshalCaddyfile(d); err == nil {
+		t.Fatal("r2 takes no inline argument")
+	}
+}
+
+func TestR2FS_UnmarshalCaddyfile_RejectsANonNumericMaxFileSize(t *testing.T) {
+	t.Parallel()
+	d := caddyfile.NewTestDispenser("r2 {\n\tmax_file_size lots\n}")
+	err := new(R2FS).UnmarshalCaddyfile(d)
+	if err == nil || !strings.Contains(err.Error(), "max_file_size") {
+		t.Fatalf("expected a max_file_size parse error, got %v", err)
+	}
+}
+
 func TestR2FS_UnmarshalCaddyfile_UnknownToken(t *testing.T) {
 	t.Parallel()
 	const input = `r2 {
@@ -327,20 +359,144 @@ func TestR2FS_Open_RejectsOversizeObject(t *testing.T) {
 	}
 }
 
-func TestR2FS_Open_LoadFailureSurfacesOnRead(t *testing.T) {
+func TestR2FS_Open_UpstreamErrorIsNotAPathError(t *testing.T) {
 	t.Parallel()
 	r := newTestR2FS()
-	r.header = stubFSFetcher(&r2Object{Size: 10}, nil)
-	r.fetcher = stubFSFetcher(nil, fs.ErrNotExist)
+	r.header = stubFSFetcher(nil, errors.New("caddy.fs.r2: upstream 5xx: service unavailable"))
 
-	f, err := r.Open("site-a.test.camp/deploys/v1/vanished.html")
+	_, err := r.Open("site-a.test.camp/deploys/v1/index.html")
+	if err == nil {
+		t.Fatal("Open should fail on an upstream error")
+	}
+	var pe *fs.PathError
+	if errors.As(err, &pe) {
+		t.Fatalf("caddy maps any *fs.PathError to 400 (staticfiles.go mapDirOpenError), got %T", err)
+	}
+	if errors.Is(err, fs.ErrInvalid) || errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("an upstream error must not read as invalid or missing, got %v", err)
+	}
+}
+
+func TestR2FS_Open_SeekSurfacesTheBodyFetchFailure(t *testing.T) {
+	t.Parallel()
+	fetchErr := errors.New("caddy.fs.r2: upstream 5xx: GetObject failed")
+	r := newTestR2FS()
+	r.header = stubFSFetcher(&r2Object{Size: 4096}, nil)
+	r.fetcher = stubFSFetcher(nil, fetchErr)
+
+	f, err := r.Open("site-a.test.camp/deploys/v1/index.html")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
 	defer func() { _ = f.Close() }()
 
-	if _, readErr := f.Read(make([]byte, 4)); !errors.Is(readErr, fs.ErrNotExist) {
-		t.Fatalf("read after the object vanished: want fs.ErrNotExist, got %v", readErr)
+	if _, seekErr := f.(io.Seeker).Seek(0, io.SeekEnd); !errors.Is(seekErr, fetchErr) {
+		t.Fatalf("Seek must surface the fetch failure before ServeContent commits the header, got %v", seekErr)
+	}
+}
+
+func TestR2FS_Open_ReadSurfacesTheBodyFetchFailure(t *testing.T) {
+	t.Parallel()
+	fetchErr := errors.New("caddy.fs.r2: upstream 5xx: GetObject failed")
+	r := newTestR2FS()
+	r.header = stubFSFetcher(&r2Object{Size: 4096}, nil)
+	r.fetcher = stubFSFetcher(nil, fetchErr)
+
+	f, err := r.Open("site-a.test.camp/deploys/v1/index.html")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, readErr := f.Read(make([]byte, 4)); !errors.Is(readErr, fetchErr) {
+		t.Fatalf("Read must surface the fetch failure, got %v", readErr)
+	}
+	if _, readErr := f.(io.ReaderAt).ReadAt(make([]byte, 4), 0); !errors.Is(readErr, fetchErr) {
+		t.Fatalf("ReadAt must surface the fetch failure, got %v", readErr)
+	}
+}
+
+func TestR2FS_Open_IndexProbeFailureIsNotAPathError(t *testing.T) {
+	t.Parallel()
+	r := newTestR2FS()
+	r.header = stubFSFetcher(nil, fs.ErrNotExist)
+	r.indexProbe = stubIndexProbe(false, errors.New("caddy.fs.r2: upstream 5xx"))
+
+	_, err := r.Open("site-a.test.camp/deploys/v1")
+	if err == nil {
+		t.Fatal("a failed index probe must fail Open")
+	}
+	var pe *fs.PathError
+	if errors.As(err, &pe) {
+		t.Fatalf("caddy maps any *fs.PathError to 400, got %T", err)
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("a failed probe must not read as a definite miss, got %v", err)
+	}
+}
+
+func TestR2FS_FileInfo_ModeAndSys(t *testing.T) {
+	t.Parallel()
+	file := &r2FileInfo{name: "index.html", size: 3}
+	if file.Mode() != 0o444 {
+		t.Errorf("file mode: want 0444, got %v", file.Mode())
+	}
+	if file.Sys() != nil {
+		t.Errorf("Sys should carry nothing, got %v", file.Sys())
+	}
+
+	dir := &r2FileInfo{name: "v1", isDir: true}
+	if dir.Mode()&fs.ModeDir == 0 {
+		t.Errorf("directory mode should include ModeDir, got %v", dir.Mode())
+	}
+}
+
+func TestR2FS_Stat_InvalidPath(t *testing.T) {
+	t.Parallel()
+	r := newTestR2FS()
+	r.header = func(context.Context, string) (*r2Object, error) {
+		t.Fatal("header should NOT be called on an invalid path")
+		return nil, nil
+	}
+
+	if _, err := r.Stat("/leading-slash"); !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("error should wrap fs.ErrInvalid, got %v", err)
+	}
+}
+
+func TestR2FS_Stat_UpstreamErrorPropagates(t *testing.T) {
+	t.Parallel()
+	r := newTestR2FS()
+	r.header = stubFSFetcher(nil, errors.New("caddy.fs.r2: upstream 5xx"))
+
+	_, err := r.Stat("site-a.test.camp/deploys/v1/index.html")
+	if err == nil {
+		t.Fatal("Stat should propagate an upstream error")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("an upstream error must not read as missing, got %v", err)
+	}
+}
+
+func TestR2FS_Stat_ProbeFailurePropagates(t *testing.T) {
+	t.Parallel()
+	r := newTestR2FS()
+	r.header = stubFSFetcher(nil, fs.ErrNotExist)
+	r.indexProbe = stubIndexProbe(false, errors.New("caddy.fs.r2: upstream 5xx"))
+
+	if _, err := r.Stat("site-a.test.camp/deploys/v1"); err == nil {
+		t.Fatal("Stat should propagate a failed index probe")
+	}
+}
+
+func TestR2FS_Stat_NoIndexIsNotExist(t *testing.T) {
+	t.Parallel()
+	r := newTestR2FS()
+	r.header = stubFSFetcher(nil, fs.ErrNotExist)
+	r.indexProbe = stubIndexProbe(false, nil)
+
+	if _, err := r.Stat("site-a.test.camp/deploys/v1/missing"); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("error should wrap fs.ErrNotExist, got %v", err)
 	}
 }
 
@@ -380,14 +536,12 @@ func TestR2FS_Stat_VirtualDirectory(t *testing.T) {
 	}
 }
 
-func TestR2FS_Open_SeekEndDoesNotFetchTheBody(t *testing.T) {
+func TestR2FS_Open_SeekSizeMatchesTheDeliveredBody(t *testing.T) {
+	t.Parallel()
+	body := []byte("SHORT-BODY")
 	r := newTestR2FS()
 	r.header = stubFSFetcher(&r2Object{Size: 5000}, nil)
-	fetched := false
-	r.fetcher = func(context.Context, string) (*r2Object, error) {
-		fetched = true
-		return &r2Object{Body: []byte("SHORT-BODY")}, nil
-	}
+	r.fetcher = stubFSFetcher(&r2Object{Body: body, Size: 5000}, nil)
 
 	f, err := r.Open("site-a.test.camp/deploys/v1/index.html")
 	if err != nil {
@@ -399,26 +553,59 @@ func TestR2FS_Open_SeekEndDoesNotFetchTheBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Seek: unexpected error: %v", err)
 	}
-	if size != 5000 {
-		t.Errorf("Seek(0, SeekEnd): want the HeadObject size 5000, got %d", size)
+	if size != int64(len(body)) {
+		t.Errorf("Seek(0, SeekEnd): want %d, got %d", len(body), size)
 	}
-	if fetched {
-		t.Error("sizing the response must not fetch the body")
+
+	if _, err := f.(io.Seeker).Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek to start: %v", err)
+	}
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("body: want %q, got %q", body, got)
 	}
 }
 
-func TestR2FS_Open_SkewedBodyFailsTheRead(t *testing.T) {
+func TestR2FS_Open_ReadAtServesARange(t *testing.T) {
+	t.Parallel()
 	r := newTestR2FS()
-	r.header = stubFSFetcher(&r2Object{Size: 5000}, nil)
-	r.fetcher = stubFSFetcher(&r2Object{Body: []byte("SHORT-BODY")}, nil)
+	r.fetcher = stubFSFetcher(&r2Object{Body: []byte("abcdefghij")}, nil)
 
-	f, err := r.Open("site-a.test.camp/deploys/v1/index.html")
+	f, err := r.Open("alpha.txt")
 	if err != nil {
-		t.Fatalf("Open: unexpected error: %v", err)
+		t.Fatalf("Open: %v", err)
 	}
 	defer func() { _ = f.Close() }()
 
-	if _, err := io.ReadAll(f); err == nil {
-		t.Fatal("a body shorter than the declared size must fail, not short-serve")
+	buf := make([]byte, 3)
+	if _, err := f.(io.ReaderAt).ReadAt(buf, 4); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if string(buf) != "efg" {
+		t.Errorf("ReadAt(4): want %q, got %q", "efg", buf)
+	}
+}
+
+func TestR2FS_Open_VirtualDirectoryReadsEmpty(t *testing.T) {
+	t.Parallel()
+	r := newTestR2FS()
+	r.fetcher = stubFSFetcher(nil, fs.ErrNotExist)
+	r.indexProbe = stubIndexProbe(true, nil)
+
+	f, err := r.Open("site-a.test.camp/deploys/v1")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("ReadAll on a virtual directory: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("a virtual directory must read empty, got %q", got)
 	}
 }

--- a/caddy-r2alias/go.mod
+++ b/caddy-r2alias/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1
+	github.com/aws/smithy-go v1.25.0
 	github.com/caddyserver/caddy/v2 v2.11.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/prometheus/client_golang v1.23.2
 	go.uber.org/zap v1.27.1
 	golang.org/x/sync v0.20.0
 )
@@ -44,7 +46,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 // indirect
-	github.com/aws/smithy-go v1.25.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/caddyserver/certmagic v0.25.3 // indirect
 	github.com/caddyserver/zerossl v0.1.5 // indirect
@@ -89,6 +90,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libdns/libdns v1.1.1 // indirect
 	github.com/manifoldco/promptui v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -103,7 +105,6 @@ require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pires/go-proxyproto v0.11.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect

--- a/caddy-r2alias/host.go
+++ b/caddy-r2alias/host.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// https://github.com/caddyserver/caddy/blob/v2.11.3/modules/caddyhttp/matchers.go#L308-L316
+// https://github.com/caddyserver/caddy/blob/v2.11.3/modules/caddyhttp/matchers.go#L308-L315
 func normaliseHost(host string) string {
 	if bare, _, err := net.SplitHostPort(host); err == nil {
 		host = bare

--- a/caddy-r2alias/host.go
+++ b/caddy-r2alias/host.go
@@ -2,8 +2,19 @@ package r2alias
 
 import (
 	"fmt"
+	"net"
 	"strings"
 )
+
+// https://github.com/caddyserver/caddy/blob/v2.11.3/modules/caddyhttp/matchers.go#L308-L316
+func normaliseHost(host string) string {
+	if bare, _, err := net.SplitHostPort(host); err == nil {
+		host = bare
+	}
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	return strings.ToLower(strings.TrimSuffix(host, "."))
+}
 
 // parseSiteAndAlias extracts (site, alias) from a Host header.
 //
@@ -19,6 +30,10 @@ func parseSiteAndAlias(host, rootDomain, previewSubdomain string) (site, alias s
 	if strings.ContainsAny(host, `/\`) {
 		return "", "", fmt.Errorf("host %q contains a path separator", host)
 	}
+
+	host = normaliseHost(host)
+	rootDomain = strings.ToLower(rootDomain)
+	previewSubdomain = strings.ToLower(previewSubdomain)
 
 	suffix := "." + rootDomain
 	if !strings.HasSuffix(host, suffix) {

--- a/caddy-r2alias/host_test.go
+++ b/caddy-r2alias/host_test.go
@@ -49,6 +49,30 @@ func TestParseSiteAndAlias_TableDriven(t *testing.T) {
 			wantAlias: "preview",
 		},
 		{
+			name:      "explicit port ignored",
+			host:      "hello-world.freecode.camp:80",
+			wantSite:  "hello-world.freecode.camp",
+			wantAlias: "production",
+		},
+		{
+			name:      "uppercase host folded",
+			host:      "Hello-World.FreeCode.Camp",
+			wantSite:  "hello-world.freecode.camp",
+			wantAlias: "production",
+		},
+		{
+			name:      "fully qualified trailing dot accepted",
+			host:      "hello-world.freecode.camp.",
+			wantSite:  "hello-world.freecode.camp",
+			wantAlias: "production",
+		},
+		{
+			name:      "uppercase preview label folded",
+			host:      "Hello.PREVIEW.freecode.camp:443",
+			wantSite:  "hello.freecode.camp",
+			wantAlias: "preview",
+		},
+		{
 			name:    "non-root domain rejected",
 			host:    "other.com",
 			wantErr: true,

--- a/caddy-r2alias/integration_test.go
+++ b/caddy-r2alias/integration_test.go
@@ -33,10 +33,11 @@ const (
 )
 
 const (
-	documentCacheControl = "public, max-age=0, must-revalidate"
-	errorCacheControl    = "no-store"
-	chartMaxFileSize     = "33554432"
-	chartMetricsPort     = "9180"
+	documentCacheControl  = "public, max-age=0, must-revalidate"
+	errorCacheControl     = "no-store"
+	chartMaxFileSize      = "33554432"
+	chartMetricsPort      = "9180"
+	chartMaxInFlightBytes = "100663296"
 )
 
 // The disk layout is independent of the S3 prefix so one fixture set can back

--- a/caddy-r2alias/integration_test.go
+++ b/caddy-r2alias/integration_test.go
@@ -33,8 +33,9 @@ const (
 )
 
 const (
-	documentCacheControl = "public, max-age=0, must-revalidate, s-maxage=86400"
+	documentCacheControl = "public, max-age=0, must-revalidate"
 	errorCacheControl    = "no-store"
+	chartMaxFileSize     = "33554432"
 )
 
 // The disk layout is independent of the S3 prefix so one fixture set can back

--- a/caddy-r2alias/integration_test.go
+++ b/caddy-r2alias/integration_test.go
@@ -32,6 +32,11 @@ const (
 	caddyHTTPSPort = 9443
 )
 
+const (
+	documentCacheControl = "public, max-age=0, must-revalidate, s-maxage=86400"
+	errorCacheControl    = "no-store"
+)
+
 // The disk layout is independent of the S3 prefix so one fixture set can back
 // multiple site names.
 func uploadDeployFixtures(t *testing.T, stub *s3Stub, site, version string) {
@@ -82,26 +87,44 @@ func startCaddy(t *testing.T, s3Endpoint string) *caddytest.Tester {
 }
 
 :%d {
-	r2_alias {
-		bucket %s
-		endpoint %s
-		region us-east-1
-		access_key_id test
-		secret_access_key test
-		cache_ttl %s
-		fetch_timeout 2s
-		root_domain %s
+	handle {
+		header Cache-Control "%s"
+
+		r2_alias {
+			bucket %s
+			endpoint %s
+			region us-east-1
+			access_key_id test
+			secret_access_key test
+			cache_ttl %s
+			fetch_timeout 2s
+			root_domain %s
+		}
+		file_server {
+			fs r2
+		}
 	}
-	file_server {
-		fs r2
+
+	handle_errors {
+		header Cache-Control "%s"
+
+		@404 expression {err.status_code} == 404
+		respond @404 "Not Found" 404
+
+		@503 expression {err.status_code} == 503
+		respond @503 "Service Unavailable" 503
+
+		respond "Server Error" 500
 	}
 }
 `,
 		caddyAdminPort, caddyHTTPPort, caddyHTTPSPort,
 		testBucket, s3Endpoint,
 		caddyHTTPPort,
+		documentCacheControl,
 		testBucket, s3Endpoint,
 		cacheTTL, rootDomain,
+		errorCacheControl,
 	)
 	tester := caddytest.NewTester(t)
 	tester.InitServer(caddyfile, "caddyfile")
@@ -273,6 +296,37 @@ func TestIntegration_ServesIndexWithOneBodyFetch(t *testing.T) {
 	}
 }
 
+func TestIntegration_ServedObjectTellsTheBrowserToRevalidate(t *testing.T) {
+	stub := startS3Stub(t)
+	site := "site-a." + rootDomain
+
+	uploadDeployFixtures(t, stub, site, "v1")
+	stub.putAlias(site, "production", "v1")
+
+	tester := startCaddy(t, stub.endpoint())
+
+	resp, _ := doGetResponse(t, tester, site, "/index.html")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != documentCacheControl {
+		t.Fatalf("Cache-Control: want %q, got %q", documentCacheControl, got)
+	}
+}
+
+func TestIntegration_ErrorResponseIsNeverStored(t *testing.T) {
+	stub := startS3Stub(t)
+	tester := startCaddy(t, stub.endpoint())
+
+	resp, _ := doGetResponse(t, tester, "dead."+rootDomain, "/")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: want 404, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != errorCacheControl {
+		t.Fatalf("Cache-Control on a 404: want %q, got %q", errorCacheControl, got)
+	}
+}
+
 func TestIntegration_BareNotFoundAliasIs404(t *testing.T) {
 	stub := startS3Stub(t)
 	stub.setFailure(http.StatusNotFound)
@@ -297,6 +351,36 @@ func TestIntegration_UpstreamServerErrorIs503(t *testing.T) {
 	}
 }
 
+func TestIntegration_BodyFetchFailureNeverServes200(t *testing.T) {
+	stub := startS3Stub(t)
+	site := "site-a." + rootDomain
+
+	uploadDeployFixtures(t, stub, site, "v1")
+	stub.putAlias(site, "production", "v1")
+	stub.failGetForKeyOnly(site+"/deploys/v1/index.html", http.StatusInternalServerError)
+
+	tester := startCaddy(t, stub.endpoint())
+
+	url := fmt.Sprintf("http://localhost:%d/index.html", caddyHTTPPort)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = site
+
+	resp, err := tester.Client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /index.html: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, readErr := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 500 {
+		t.Fatalf("r2 body fetch failed, caddy answered %d (delivered=%d readErr=%v); status monitoring cannot see the outage",
+			resp.StatusCode, len(body), readErr)
+	}
+}
+
 func TestIntegration_MissingSite404(t *testing.T) {
 	stub := startS3Stub(t)
 	tester := startCaddy(t, stub.endpoint())
@@ -307,23 +391,7 @@ func TestIntegration_MissingSite404(t *testing.T) {
 	}
 }
 
-// TestIntegration_HeadGetSizeSkewNeverLooksComplete covers an object changing
-// between the HeadObject and the GetObject. Sizing the response truthfully would
-// cost a body fetch on every HEAD, so the response is allowed to break — but it
-// must never look like a complete short body.
-//
-// The failure is a truncated 200, not an error status: caddy has already
-// committed the header when the mismatch surfaces, so status-code monitoring
-// sees a healthy 200 and only a body-length check catches it.
-//
-// Reachability: artemis refuses to delete or move a deploy under a live alias
-// (409 deploy_aliased, internal/handler/deploy_delete.go), and GC, reconcile,
-// restore and rollback are all likewise guarded or byte-identical. The one path
-// that can overwrite a served key is the deploy session's own repeatable upload
-// — the deploy JWT outlives finalize, so the uploader can PUT over a key that
-// finalize just aliased. That is a narrow race, and only an authorized session
-// can open it.
-func TestIntegration_HeadGetSizeSkewNeverLooksComplete(t *testing.T) {
+func TestIntegration_HeadGetSizeSkewServesTheTrueLength(t *testing.T) {
 	stub := startS3Stub(t)
 	site := "site-a." + rootDomain
 
@@ -333,39 +401,19 @@ func TestIntegration_HeadGetSizeSkewNeverLooksComplete(t *testing.T) {
 
 	tester := startCaddy(t, stub.endpoint())
 
-	url := fmt.Sprintf("http://localhost:%d/skew.html", caddyHTTPPort)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		t.Fatalf("new request: %v", err)
+	resp, body := doGetResponse(t, tester, site, "/skew.html")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
 	}
-	req.Host = site
-
-	resp, err := tester.Client.Do(req)
-	if err != nil {
-		// Only a truncated body is an acceptable transport failure here. Any
-		// other error means the server never came up and the test proved nothing.
-		if !strings.Contains(err.Error(), "EOF") {
-			t.Fatalf("GET /skew.html failed for an unrelated reason: %v", err)
-		}
-		return
+	if body != "SHORT-BODY" {
+		t.Fatalf("body: want %q, got %q", "SHORT-BODY", body)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, readErr := io.ReadAll(resp.Body)
-	if readErr != nil {
-		return
-	}
-	if int64(len(body)) != resp.ContentLength {
-		t.Fatalf("silent short body: declared %d, delivered %d (%q)",
-			resp.ContentLength, len(body), body)
+	if resp.ContentLength != int64(len(body)) {
+		t.Fatalf("declared %d, delivered %d", resp.ContentLength, len(body))
 	}
 }
 
-// TestIntegration_HeadDoesNotFetchTheBody pins the cost of a HEAD. Sizing the
-// response from a lazily-loaded body would make every HEAD pull the whole
-// object from R2 and discard it, which turns a cheap request into an origin
-// fetch bounded only by max_file_size.
-func TestIntegration_HeadDoesNotFetchTheBody(t *testing.T) {
+func TestIntegration_HeadCostsOneBodyFetchAndSizesTruthfully(t *testing.T) {
 	stub := startS3Stub(t)
 	site := "site-a." + rootDomain
 
@@ -373,7 +421,7 @@ func TestIntegration_HeadDoesNotFetchTheBody(t *testing.T) {
 	stub.putAlias(site, "production", "v1")
 
 	tester := startCaddy(t, stub.endpoint())
-	doGet(t, tester, site, "/index.html")
+	_, want := doGet(t, tester, site, "/index.html")
 
 	before := len(stub.allOps())
 	req, err := http.NewRequest(http.MethodHead,
@@ -392,10 +440,17 @@ func TestIntegration_HeadDoesNotFetchTheBody(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: want 200, got %d", resp.StatusCode)
 	}
+	if resp.ContentLength != int64(len(want)) {
+		t.Errorf("Content-Length: want the delivered %d, got %d", len(want), resp.ContentLength)
+	}
 
+	gets := 0
 	for _, op := range stub.allOps()[before:] {
-		if strings.HasPrefix(op, "GET ") {
-			t.Fatalf("a HEAD must not fetch the body; ops were %v", stub.allOps()[before:])
+		if strings.HasPrefix(op, http.MethodGet+" ") {
+			gets++
 		}
+	}
+	if gets != 1 {
+		t.Fatalf("body fetches for one HEAD: want 1, got %d (ops=%v)", gets, stub.allOps()[before:])
 	}
 }

--- a/caddy-r2alias/integration_test.go
+++ b/caddy-r2alias/integration_test.go
@@ -66,6 +66,15 @@ func uploadDeployFixtures(t *testing.T, stub *s3Stub, site, version string) {
 
 func startCaddy(t *testing.T, s3Endpoint string) *caddytest.Tester {
 	t.Helper()
+	return startCaddyWithMaxFileSize(t, s3Endpoint, 0)
+}
+
+func startCaddyWithMaxFileSize(t *testing.T, s3Endpoint string, maxFileSize int64) *caddytest.Tester {
+	t.Helper()
+	sizeDirective := ""
+	if maxFileSize > 0 {
+		sizeDirective = fmt.Sprintf("max_file_size %d", maxFileSize)
+	}
 	caddyfile := fmt.Sprintf(`
 {
 	admin localhost:%d
@@ -83,6 +92,7 @@ func startCaddy(t *testing.T, s3Endpoint string) *caddytest.Tester {
 		access_key_id test
 		secret_access_key test
 		use_path_style
+		%s
 	}
 }
 
@@ -111,6 +121,9 @@ func startCaddy(t *testing.T, s3Endpoint string) *caddytest.Tester {
 		@404 expression {err.status_code} == 404
 		respond @404 "Not Found" 404
 
+		@400 expression {err.status_code} == 400
+		respond @400 "Bad Request" 400
+
 		@503 expression {err.status_code} == 503
 		respond @503 "Service Unavailable" 503
 
@@ -119,7 +132,7 @@ func startCaddy(t *testing.T, s3Endpoint string) *caddytest.Tester {
 }
 `,
 		caddyAdminPort, caddyHTTPPort, caddyHTTPSPort,
-		testBucket, s3Endpoint,
+		testBucket, s3Endpoint, sizeDirective,
 		caddyHTTPPort,
 		documentCacheControl,
 		testBucket, s3Endpoint,
@@ -314,6 +327,28 @@ func TestIntegration_ServedObjectTellsTheBrowserToRevalidate(t *testing.T) {
 	}
 }
 
+func TestIntegration_OversizeObjectAnswers400(t *testing.T) {
+	stub := startS3Stub(t)
+	site := "site-a." + rootDomain
+
+	uploadDeployFixtures(t, stub, site, "v1")
+	stub.putAlias(site, "production", "v1")
+	stub.put(site+"/deploys/v1/big.html", strings.Repeat("x", 512), "text/html")
+
+	tester := startCaddyWithMaxFileSize(t, stub.endpoint(), 64)
+
+	resp, body := doGetResponse(t, tester, site, "/big.html")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d (body=%q)", resp.StatusCode, body)
+	}
+	if body != "Bad Request" {
+		t.Errorf("handle_errors should answer the oversize case, got %q", body)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != errorCacheControl {
+		t.Errorf("Cache-Control on a 400: want %q, got %q", errorCacheControl, got)
+	}
+}
+
 func TestIntegration_ErrorResponseIsNeverStored(t *testing.T) {
 	stub := startS3Stub(t)
 	tester := startCaddy(t, stub.endpoint())
@@ -375,9 +410,66 @@ func TestIntegration_BodyFetchFailureNeverServes200(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	body, readErr := io.ReadAll(resp.Body)
 
-	if resp.StatusCode < 500 {
+	if resp.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("r2 body fetch failed, caddy answered %d (delivered=%d readErr=%v); status monitoring cannot see the outage",
 			resp.StatusCode, len(body), readErr)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "" {
+		t.Errorf("ServeContent writes this error itself, so handle_errors cannot set a header; got %q", got)
+	}
+	if strings.Contains(string(body), "Server Error") {
+		t.Errorf("handle_errors is unreachable on this path; body was %q", body)
+	}
+}
+
+func TestIntegration_HeadFailureReachesTheVisitorAs5xx(t *testing.T) {
+	stub := startS3Stub(t)
+	site := "site-a." + rootDomain
+
+	uploadDeployFixtures(t, stub, site, "v1")
+	stub.putAlias(site, "production", "v1")
+	stub.failEveryMethodForKeyOnly(site+"/deploys/v1/index.html", http.StatusInternalServerError)
+
+	tester := startCaddy(t, stub.endpoint())
+
+	resp, body := doGetResponse(t, tester, site, "/index.html")
+	if resp.StatusCode < 500 {
+		t.Fatalf("an R2 metadata failure must reach the visitor as 5xx, got %d (body=%q)", resp.StatusCode, body)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		t.Fatal("caddy's mapDirOpenError walk must not downgrade an outage to a 404")
+	}
+}
+
+func TestIntegration_HeadOnASkewedObjectSizesTruthfully(t *testing.T) {
+	stub := startS3Stub(t)
+	site := "site-a." + rootDomain
+
+	uploadDeployFixtures(t, stub, site, "v1")
+	stub.putAlias(site, "production", "v1")
+	stub.putSkewed(site+"/deploys/v1/skew.html", "SHORT-BODY", "text/html", 5000)
+
+	tester := startCaddy(t, stub.endpoint())
+
+	req, err := http.NewRequest(http.MethodHead,
+		fmt.Sprintf("http://localhost:%d/skew.html", caddyHTTPPort), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = site
+
+	resp, err := tester.Client.Do(req)
+	if err != nil {
+		t.Fatalf("HEAD /skew.html: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+	if resp.ContentLength != int64(len("SHORT-BODY")) {
+		t.Fatalf("Content-Length: want the true %d, got the HeadObject %d",
+			len("SHORT-BODY"), resp.ContentLength)
 	}
 }
 

--- a/caddy-r2alias/integration_test.go
+++ b/caddy-r2alias/integration_test.go
@@ -36,6 +36,7 @@ const (
 	documentCacheControl = "public, max-age=0, must-revalidate"
 	errorCacheControl    = "no-store"
 	chartMaxFileSize     = "33554432"
+	chartMetricsPort     = "9180"
 )
 
 // The disk layout is independent of the S3 prefix so one fixture set can back
@@ -118,12 +119,16 @@ func startCaddyWithMaxFileSize(t *testing.T, s3Endpoint string, maxFileSize int6
 
 	handle_errors {
 		header Cache-Control "%s"
+		header -Etag
 
 		@404 expression {err.status_code} == 404
 		respond @404 "Not Found" 404
 
 		@400 expression {err.status_code} == 400
 		respond @400 "Bad Request" 400
+
+		@405 expression {err.status_code} == 405
+		respond @405 "Method Not Allowed" 405
 
 		@503 expression {err.status_code} == 503
 		respond @503 "Service Unavailable" 503
@@ -471,6 +476,109 @@ func TestIntegration_HeadOnASkewedObjectSizesTruthfully(t *testing.T) {
 	if resp.ContentLength != int64(len("SHORT-BODY")) {
 		t.Fatalf("Content-Length: want the true %d, got the HeadObject %d",
 			len("SHORT-BODY"), resp.ContentLength)
+	}
+}
+
+func TestIntegration_ValidatorChangesWithTheDeploy(t *testing.T) {
+	stub := startS3Stub(t)
+	site := "site-a." + rootDomain
+
+	uploadDeployFixtures(t, stub, site, "v1")
+	uploadDeployFixtures(t, stub, site, "v2")
+	stub.putAlias(site, "production", "v1")
+
+	tester := startCaddy(t, stub.endpoint())
+
+	first, _ := doGetResponse(t, tester, site, "/index.html")
+	firstTag := first.Header.Get("Etag")
+	if firstTag == "" {
+		t.Fatal("a served object must carry a validator")
+	}
+
+	stub.putAlias(site, "production", "v2")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		next, _ := doGetResponse(t, tester, site, "/index.html")
+		if tag := next.Header.Get("Etag"); tag != firstTag {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("the validator never changed after the alias flip: still %s", firstTag)
+}
+
+func TestIntegration_ConditionalRequestAfterAFlipRefetches(t *testing.T) {
+	stub := startS3Stub(t)
+	site := "site-a." + rootDomain
+
+	uploadDeployFixtures(t, stub, site, "v1")
+	uploadDeployFixtures(t, stub, site, "v2")
+	stub.putAlias(site, "production", "v1")
+
+	tester := startCaddy(t, stub.endpoint())
+
+	first, firstBody := doGetResponse(t, tester, site, "/index.html")
+	staleTag := first.Header.Get("Etag")
+	assertBodyContains(t, firstBody, "V1")
+
+	stub.putAlias(site, "production", "v2")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequest(http.MethodGet,
+			fmt.Sprintf("http://localhost:%d/index.html", caddyHTTPPort), nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Host = site
+		req.Header.Set("If-None-Match", staleTag)
+
+		resp, err := tester.Client.Do(req)
+		if err != nil {
+			t.Fatalf("conditional GET: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode == http.StatusNotModified {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status: want 200, got %d", resp.StatusCode)
+		}
+		assertBodyContains(t, string(body), "V2")
+		return
+	}
+	t.Fatal("a stale validator kept answering 304 after the alias flip")
+}
+
+func TestIntegration_UnsupportedMethodAnswers405(t *testing.T) {
+	stub := startS3Stub(t)
+	site := "site-a." + rootDomain
+
+	uploadDeployFixtures(t, stub, site, "v1")
+	stub.putAlias(site, "production", "v1")
+
+	tester := startCaddy(t, stub.endpoint())
+
+	req, err := http.NewRequest(http.MethodDelete,
+		fmt.Sprintf("http://localhost:%d/index.html", caddyHTTPPort), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = site
+
+	resp, err := tester.Client.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /index.html: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status: want 405, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Etag"); got != "" {
+		t.Errorf("an error response must not carry a validator, got %q", got)
 	}
 }
 

--- a/caddy-r2alias/metrics.go
+++ b/caddy-r2alias/metrics.go
@@ -35,7 +35,7 @@ var moduleMetrics = struct {
 	inFlight   prometheus.Gauge
 }{}
 
-func initMetrics(registry prometheus.Registerer) error {
+func initMetrics(registry *prometheus.Registry) error {
 	moduleMetrics.once.Do(func() {
 		moduleMetrics.operations = prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricNamespace,

--- a/caddy-r2alias/metrics.go
+++ b/caddy-r2alias/metrics.go
@@ -1,0 +1,95 @@
+package r2alias
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricNamespace = "caddy"
+	metricSubsystem = "r2alias"
+)
+
+const (
+	opHead  = "head"
+	opGet   = "get"
+	opAlias = "alias"
+)
+
+const (
+	resultOK       = "ok"
+	resultNotFound = "not_found"
+	resultTooLarge = "too_large"
+	resultError    = "error"
+	resultHit      = "hit"
+	resultMiss     = "miss"
+)
+
+var moduleMetrics = struct {
+	once       sync.Once
+	operations *prometheus.CounterVec
+	lookups    *prometheus.CounterVec
+	inFlight   prometheus.Gauge
+}{}
+
+func initMetrics(registry prometheus.Registerer) {
+	moduleMetrics.once.Do(func() {
+		moduleMetrics.operations = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "r2_operations_total",
+			Help:      "R2 round trips by operation and outcome.",
+		}, []string{"operation", "result"})
+
+		moduleMetrics.lookups = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "alias_lookups_total",
+			Help:      "Alias resolutions by cache outcome.",
+		}, []string{"result"})
+
+		moduleMetrics.inFlight = prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "buffered_bytes",
+			Help:      "Object bytes currently held in memory for in-flight responses.",
+		})
+	})
+
+	if registry == nil {
+		return
+	}
+	for _, c := range []prometheus.Collector{
+		moduleMetrics.operations, moduleMetrics.lookups, moduleMetrics.inFlight,
+	} {
+		if err := registry.Register(c); err != nil {
+			var already prometheus.AlreadyRegisteredError
+			if !errors.As(err, &already) {
+				panic(err)
+			}
+		}
+	}
+}
+
+func recordOperation(operation, result string) {
+	if moduleMetrics.operations == nil {
+		return
+	}
+	moduleMetrics.operations.WithLabelValues(operation, result).Inc()
+}
+
+func recordLookup(result string) {
+	if moduleMetrics.lookups == nil {
+		return
+	}
+	moduleMetrics.lookups.WithLabelValues(result).Inc()
+}
+
+func addBufferedBytes(delta float64) {
+	if moduleMetrics.inFlight == nil {
+		return
+	}
+	moduleMetrics.inFlight.Add(delta)
+}

--- a/caddy-r2alias/metrics.go
+++ b/caddy-r2alias/metrics.go
@@ -2,6 +2,7 @@ package r2alias
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -34,7 +35,7 @@ var moduleMetrics = struct {
 	inFlight   prometheus.Gauge
 }{}
 
-func initMetrics(registry prometheus.Registerer) {
+func initMetrics(registry prometheus.Registerer) error {
 	moduleMetrics.once.Do(func() {
 		moduleMetrics.operations = prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricNamespace,
@@ -59,7 +60,7 @@ func initMetrics(registry prometheus.Registerer) {
 	})
 
 	if registry == nil {
-		return
+		return nil
 	}
 	for _, c := range []prometheus.Collector{
 		moduleMetrics.operations, moduleMetrics.lookups, moduleMetrics.inFlight,
@@ -67,10 +68,11 @@ func initMetrics(registry prometheus.Registerer) {
 		if err := registry.Register(c); err != nil {
 			var already prometheus.AlreadyRegisteredError
 			if !errors.As(err, &already) {
-				panic(err)
+				return fmt.Errorf("register %T: %w", c, err)
 			}
 		}
 	}
+	return nil
 }
 
 func recordOperation(operation, result string) {

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -490,31 +490,30 @@ func TestR2FS_ReweighBudget_CapsConcurrentGrowWaits(t *testing.T) {
 	r.budget = semaphore.NewWeighted(64)
 	r.growWaits = semaphore.NewWeighted(1)
 
-	if err := r.acquireBudget(context.Background(), 64); err != nil {
+	if err := r.acquireBudget(context.Background(), 1); err != nil {
+		t.Fatalf("our own charge: %v", err)
+	}
+	if err := r.acquireBudget(context.Background(), 63); err != nil {
 		t.Fatalf("fill the budget: %v", err)
 	}
+	if !r.growWaits.TryAcquire(1) {
+		t.Fatal("the only wait slot must start free")
+	}
 
-	waiting := make(chan struct{})
-	done := make(chan struct{})
-	go func() {
-		close(waiting)
-		_, _ = r.reweighBudget(1, 32)
-		close(done)
-	}()
-	<-waiting
-
-	deadline := time.Now().Add(budgetGrowWait)
-	for time.Now().Before(deadline) {
-		if _, err := r.reweighBudget(1, 32); err != nil {
-			if !strings.Contains(err.Error(), "already waiting") {
-				continue
-			}
-			<-done
-			return
-		}
+	start := time.Now()
+	held, err := r.reweighBudget(1, 32)
+	if err == nil {
 		t.Fatal("the budget is full, so no grow can succeed")
 	}
-	t.Fatal("a second grow must be refused while the cap is taken, not queued behind it")
+	if !strings.Contains(err.Error(), "already waiting") {
+		t.Fatalf("a grow past the wait cap must be refused at once, got %v", err)
+	}
+	if held != 0 {
+		t.Errorf("a refused grow must report nothing held, got %d", held)
+	}
+	if elapsed := time.Since(start); elapsed >= budgetGrowWait {
+		t.Errorf("the refusal must be immediate, took %s", elapsed)
+	}
 }
 
 func TestR2FS_ReweighBudget_GrowReleasesBeforeItWaits(t *testing.T) {

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"io/fs"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/smithy-go/logging"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/zap"
@@ -23,7 +24,7 @@ func TestResolvePlaceholders_ResolvesEnvAtProvision(t *testing.T) {
 	t.Setenv("R2ALIAS_TEST_BUCKET", "universe-static-apps-01")
 
 	bucket := "{env.R2ALIAS_TEST_BUCKET}"
-	if err := resolvePlaceholders(&bucket); err != nil {
+	if err := resolvePlaceholders(map[string]*string{"bucket": &bucket}); err != nil {
 		t.Fatalf("resolvePlaceholders: %v", err)
 	}
 	if bucket != "universe-static-apps-01" {
@@ -35,14 +36,14 @@ func TestResolvePlaceholders_FailsOnAnEmptyEnvVar(t *testing.T) {
 	t.Setenv("R2ALIAS_TEST_EMPTY", "")
 
 	secret := "{env.R2ALIAS_TEST_EMPTY}"
-	if err := resolvePlaceholders(&secret); err == nil {
+	if err := resolvePlaceholders(map[string]*string{"secret_access_key": &secret}); err == nil {
 		t.Fatal("an unset credential must fail the load, not sign with an empty key")
 	}
 }
 
 func TestResolvePlaceholders_LeavesAPlainValueAlone(t *testing.T) {
 	value := "universe-static-apps-01"
-	if err := resolvePlaceholders(&value); err != nil {
+	if err := resolvePlaceholders(map[string]*string{"endpoint": &value}); err != nil {
 		t.Fatalf("resolvePlaceholders: %v", err)
 	}
 	if value != "universe-static-apps-01" {
@@ -52,7 +53,7 @@ func TestResolvePlaceholders_LeavesAPlainValueAlone(t *testing.T) {
 
 func TestResolvePlaceholders_RejectsARegexQuantifier(t *testing.T) {
 	pattern := defaultDeployIDRegex
-	if err := resolvePlaceholders(&pattern); err == nil {
+	if err := resolvePlaceholders(map[string]*string{"deploy_id_regex": &pattern}); err == nil {
 		t.Fatal("a regex quantifier reads as a placeholder, which is why Provision must never pass one")
 	}
 }
@@ -101,9 +102,9 @@ func TestSharedS3Client_ReusesOneClientPerConfig(t *testing.T) {
 }
 
 func TestSharedAliasCache_KeysOnTheEndpoint(t *testing.T) {
-	first, firstKey := sharedAliasCache("https://a.example", "b", 10, time.Second, time.Second)
+	first, firstKey := sharedAliasCache(r2ClientConfig{Endpoint: "https://a.example", Bucket: "b"}, 10, time.Second, time.Second)
 	t.Cleanup(func() { _, _ = aliasCaches.Delete(firstKey) })
-	second, secondKey := sharedAliasCache("https://b.example", "b", 10, time.Second, time.Second)
+	second, secondKey := sharedAliasCache(r2ClientConfig{Endpoint: "https://b.example", Bucket: "b"}, 10, time.Second, time.Second)
 	t.Cleanup(func() { _, _ = aliasCaches.Delete(secondKey) })
 
 	if first == second {
@@ -261,12 +262,6 @@ func TestMetrics_CountAliasCacheOutcomes(t *testing.T) {
 }
 
 func TestUpstreamStatus_TreatsThrottlingAsUpstream(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Retry-After", "7")
-		w.WriteHeader(http.StatusTooManyRequests)
-	}))
-	t.Cleanup(srv.Close)
-
 	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Retry-After", "7")
 		w.WriteHeader(http.StatusTooManyRequests)
@@ -321,7 +316,7 @@ func TestCleanup_ReleasesPooledResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sharedS3Client: %v", err)
 	}
-	cache, cacheKey := sharedAliasCache(cfg.Endpoint, cfg.Bucket, 4, time.Minute, time.Second)
+	cache, cacheKey := sharedAliasCache(cfg, 4, time.Minute, time.Second)
 
 	alias := &R2Alias{client: client, clientKey: clientKey, cache: cache, cacheKey: cacheKey}
 	if err := alias.Cleanup(); err != nil {
@@ -345,6 +340,14 @@ func TestR2FS_Validate_RequiresBucketAndEndpoint(t *testing.T) {
 		t.Error("endpoint is required")
 	}
 
+	tooSmall := &R2FS{
+		Bucket: "b", Endpoint: "https://r2.example",
+		MaxFileSize: 100, MaxInFlightBytes: 1,
+	}
+	if err := tooSmall.Validate(); err == nil {
+		t.Error("a budget below one object must be rejected, not silently widened")
+	}
+
 	valid := &R2FS{Bucket: "b", Endpoint: "https://r2.example"}
 	if err := valid.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
@@ -353,7 +356,92 @@ func TestR2FS_Validate_RequiresBucketAndEndpoint(t *testing.T) {
 		t.Error("R2 needs path-style addressing by default")
 	}
 	if valid.MaxInFlightBytes < valid.MaxFileSize {
-		t.Errorf("the in-flight budget %d must hold at least one object of %d",
+		t.Errorf("the default budget %d must hold at least one object of %d",
 			valid.MaxInFlightBytes, valid.MaxFileSize)
+	}
+}
+
+func TestR2FS_ReweighBudget_ChargesTheDeliveredBody(t *testing.T) {
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(64)
+
+	if err := r.acquireBudget(context.Background(), 16); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	held, err := r.reweighBudget(context.Background(), 16, 64)
+	if err != nil {
+		t.Fatalf("reweigh up: %v", err)
+	}
+	if held != 64 {
+		t.Errorf("held: want the delivered 64, got %d", held)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := r.acquireBudget(ctx, 1); err == nil {
+		t.Fatal("a body larger than its HeadObject size must still be charged in full")
+	}
+
+	r.releaseBudget(held)
+	if err := r.acquireBudget(context.Background(), 64); err != nil {
+		t.Fatalf("the full budget must return: %v", err)
+	}
+	r.releaseBudget(64)
+
+	if err := r.acquireBudget(context.Background(), 64); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	held, err = r.reweighBudget(context.Background(), 64, 8)
+	if err != nil {
+		t.Fatalf("reweigh down: %v", err)
+	}
+	if held != 8 {
+		t.Errorf("held: want the delivered 8, got %d", held)
+	}
+	if err := r.acquireBudget(context.Background(), 56); err != nil {
+		t.Fatalf("a smaller body must hand the surplus back: %v", err)
+	}
+}
+
+func TestNewBudgetedRetryer_RetriesThrottling(t *testing.T) {
+	retryer := newBudgetedRetryer(2, time.Second)
+
+	throttled := &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{
+				Response: &http.Response{StatusCode: http.StatusTooManyRequests},
+			},
+			Err: errors.New("TooManyRequests"),
+		},
+	}
+	if !retryer.IsErrorRetryable(throttled) {
+		t.Error("R2 throttling must be retryable; the SDK default set stops at 504")
+	}
+
+	serverError := &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{
+				Response: &http.Response{StatusCode: http.StatusServiceUnavailable},
+			},
+			Err: errors.New("ServiceUnavailable"),
+		},
+	}
+	if !retryer.IsErrorRetryable(serverError) {
+		t.Error("a 503 must stay retryable")
+	}
+
+	notFound := &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{
+				Response: &http.Response{StatusCode: http.StatusNotFound},
+			},
+			Err: errors.New("NoSuchKey"),
+		},
+	}
+	if retryer.IsErrorRetryable(notFound) {
+		t.Error("a missing key must not be retried")
+	}
+	if got := retryer.MaxAttempts(); got != 2 {
+		t.Errorf("MaxAttempts: want 2, got %d", got)
 	}
 }

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -368,7 +368,7 @@ func TestR2FS_ReweighBudget_ChargesTheDeliveredBody(t *testing.T) {
 	if err := r.acquireBudget(context.Background(), 16); err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
-	held, err := r.reweighBudget(context.Background(), 16, 64)
+	held, err := r.reweighBudget(16, 64)
 	if err != nil {
 		t.Fatalf("reweigh up: %v", err)
 	}
@@ -391,7 +391,7 @@ func TestR2FS_ReweighBudget_ChargesTheDeliveredBody(t *testing.T) {
 	if err := r.acquireBudget(context.Background(), 64); err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
-	held, err = r.reweighBudget(context.Background(), 64, 8)
+	held, err = r.reweighBudget(64, 8)
 	if err != nil {
 		t.Fatalf("reweigh down: %v", err)
 	}
@@ -400,6 +400,39 @@ func TestR2FS_ReweighBudget_ChargesTheDeliveredBody(t *testing.T) {
 	}
 	if err := r.acquireBudget(context.Background(), 56); err != nil {
 		t.Fatalf("a smaller body must hand the surplus back: %v", err)
+	}
+}
+
+func TestR2FS_ReweighBudget_NeverStallsOnAContendedBudget(t *testing.T) {
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(64)
+
+	for range 2 {
+		if err := r.acquireBudget(context.Background(), 32); err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+	}
+
+	start := time.Now()
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := r.reweighBudget(32, 64)
+			results <- err
+		}()
+	}
+
+	failures := 0
+	for range 2 {
+		if err := <-results; err != nil {
+			failures++
+		}
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("two concurrent reweigh-ups must not stall on each other, took %s", elapsed)
+	}
+	if failures == 2 {
+		t.Error("both reweigh attempts failed; one must win the released capacity")
 	}
 }
 

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -333,8 +333,6 @@ func TestCleanup_ReleasesPooledResources(t *testing.T) {
 }
 
 func TestR2FS_Provision_WiresBothLimiters(t *testing.T) {
-	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
-
 	r := &R2FS{Bucket: "b", Endpoint: "https://r2.example", MaxFileSize: 1024}
 	if err := r.Provision(caddy.Context{Context: context.Background()}); err != nil {
 		t.Fatalf("Provision: %v", err)
@@ -345,7 +343,7 @@ func TestR2FS_Provision_WiresBothLimiters(t *testing.T) {
 		t.Error("Provision must wire the in-flight byte budget")
 	}
 	if r.growWaits == nil {
-		t.Error("Provision must wire the grow-wait cap, or production runs unlimited")
+		t.Fatal("Provision must wire the grow-wait cap, or production runs unlimited")
 	}
 	if !r.growWaits.TryAcquire(maxConcurrentGrowWaits) {
 		t.Errorf("the grow-wait cap must start with %d free slots", maxConcurrentGrowWaits)
@@ -603,7 +601,7 @@ func TestR2FS_ReweighBudget_GrowGivesUpItsChargeWhenRefused(t *testing.T) {
 	}
 
 	if !r.growWaits.TryAcquire(maxConcurrentGrowWaits) {
-		t.Error("a refused grow must hand its wait slot back, or the cap erodes to nothing")
+		t.Fatal("a refused grow must hand its wait slot back, or the cap erodes to nothing")
 	}
 	r.growWaits.Release(maxConcurrentGrowWaits)
 

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -414,25 +414,56 @@ func TestR2FS_ReweighBudget_NeverStallsOnAContendedBudget(t *testing.T) {
 	}
 
 	start := time.Now()
-	results := make(chan error, 2)
+	results := make(chan int64, 2)
 	for range 2 {
 		go func() {
-			_, err := r.reweighBudget(32, 64)
-			results <- err
+			held, _ := r.reweighBudget(32, 64)
+			results <- held
 		}()
 	}
-
-	failures := 0
 	for range 2 {
-		if err := <-results; err != nil {
-			failures++
+		if held := <-results; held > 0 {
+			r.releaseBudget(held)
 		}
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("two concurrent reweigh-ups must not stall on each other, took %s", elapsed)
 	}
-	if failures == 2 {
-		t.Error("both reweigh attempts failed; one must win the released capacity")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := r.acquireBudget(ctx, 64); err != nil {
+		t.Fatalf("every charge must be accounted for once the reweighs settle: %v", err)
+	}
+}
+
+func TestR2FS_ReweighBudget_ShrinkSucceedsWhileAWaiterIsQueued(t *testing.T) {
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(64)
+
+	if err := r.acquireBudget(context.Background(), 8); err != nil {
+		t.Fatalf("our own charge: %v", err)
+	}
+	if err := r.acquireBudget(context.Background(), 40); err != nil {
+		t.Fatalf("another request's charge: %v", err)
+	}
+
+	queued := make(chan struct{})
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	defer cancelWaiter()
+	go func() {
+		close(queued)
+		_ = r.budget.Acquire(waiterCtx, 32)
+	}()
+	<-queued
+	time.Sleep(50 * time.Millisecond)
+
+	held, err := r.reweighBudget(8, 4)
+	if err != nil {
+		t.Fatalf("a shrink returns capacity and must never fail, even behind a queued waiter: %v", err)
+	}
+	if held != 4 {
+		t.Errorf("held: want 4, got %d", held)
 	}
 }
 

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -1,0 +1,359 @@
+package r2alias
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go/logging"
+	"github.com/caddyserver/caddy/v2"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sync/semaphore"
+)
+
+func TestResolvePlaceholders_ResolvesEnvAtProvision(t *testing.T) {
+	t.Setenv("R2ALIAS_TEST_BUCKET", "universe-static-apps-01")
+
+	bucket := "{env.R2ALIAS_TEST_BUCKET}"
+	if err := resolvePlaceholders(&bucket); err != nil {
+		t.Fatalf("resolvePlaceholders: %v", err)
+	}
+	if bucket != "universe-static-apps-01" {
+		t.Errorf("bucket: want the env value, got %q", bucket)
+	}
+}
+
+func TestResolvePlaceholders_FailsOnAnEmptyEnvVar(t *testing.T) {
+	t.Setenv("R2ALIAS_TEST_EMPTY", "")
+
+	secret := "{env.R2ALIAS_TEST_EMPTY}"
+	if err := resolvePlaceholders(&secret); err == nil {
+		t.Fatal("an unset credential must fail the load, not sign with an empty key")
+	}
+}
+
+func TestResolvePlaceholders_LeavesAPlainValueAlone(t *testing.T) {
+	value := "universe-static-apps-01"
+	if err := resolvePlaceholders(&value); err != nil {
+		t.Fatalf("resolvePlaceholders: %v", err)
+	}
+	if value != "universe-static-apps-01" {
+		t.Errorf("value: want it untouched, got %q", value)
+	}
+}
+
+func TestResolvePlaceholders_RejectsARegexQuantifier(t *testing.T) {
+	pattern := defaultDeployIDRegex
+	if err := resolvePlaceholders(&pattern); err == nil {
+		t.Fatal("a regex quantifier reads as a placeholder, which is why Provision must never pass one")
+	}
+}
+
+func TestSharedS3Client_ReusesOneClientPerConfig(t *testing.T) {
+	ctx := caddy.Context{Context: context.Background()}
+	cfg := r2ClientConfig{
+		Bucket:      "b",
+		Endpoint:    "https://r2.example",
+		Region:      "auto",
+		AccessKeyID: "kid", SecretAccessKey: "sak",
+		UsePathStyle: true,
+		MaxAttempts:  2,
+		MaxBackoff:   time.Second,
+	}
+
+	first, firstKey, err := sharedS3Client(ctx, cfg, zap.NewNop())
+	if err != nil {
+		t.Fatalf("sharedS3Client: %v", err)
+	}
+	t.Cleanup(func() { _, _ = s3Clients.Delete(firstKey) })
+
+	second, secondKey, err := sharedS3Client(ctx, cfg, zap.NewNop())
+	if err != nil {
+		t.Fatalf("sharedS3Client: %v", err)
+	}
+	t.Cleanup(func() { _, _ = s3Clients.Delete(secondKey) })
+
+	if first != second {
+		t.Error("one config must yield one client, so a reload does not leak a connection pool")
+	}
+	if firstKey != secondKey {
+		t.Errorf("pool keys diverged: %q and %q", firstKey, secondKey)
+	}
+
+	other := cfg
+	other.Endpoint = "https://other.example"
+	third, thirdKey, err := sharedS3Client(ctx, other, zap.NewNop())
+	if err != nil {
+		t.Fatalf("sharedS3Client: %v", err)
+	}
+	t.Cleanup(func() { _, _ = s3Clients.Delete(thirdKey) })
+	if third == first {
+		t.Error("a different endpoint must not share a client")
+	}
+}
+
+func TestSharedAliasCache_KeysOnTheEndpoint(t *testing.T) {
+	first, firstKey := sharedAliasCache("https://a.example", "b", 10, time.Second, time.Second)
+	t.Cleanup(func() { _, _ = aliasCaches.Delete(firstKey) })
+	second, secondKey := sharedAliasCache("https://b.example", "b", 10, time.Second, time.Second)
+	t.Cleanup(func() { _, _ = aliasCaches.Delete(secondKey) })
+
+	if first == second {
+		t.Error("two endpoints with one bucket name must not share an alias cache")
+	}
+}
+
+func TestR2FS_AcquireBudget_RefusesBeyondTheCap(t *testing.T) {
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(16)
+
+	if err := r.acquireBudget(context.Background(), 16); err != nil {
+		t.Fatalf("the first acquisition must fit: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := r.acquireBudget(ctx, 16)
+	if err == nil {
+		t.Fatal("a full budget must refuse the next body rather than grow the heap")
+	}
+	if !strings.Contains(err.Error(), "in-flight budget exhausted") {
+		t.Errorf("error should name the budget, got %v", err)
+	}
+
+	r.releaseBudget(16)
+	if err := r.acquireBudget(context.Background(), 16); err != nil {
+		t.Fatalf("Close must return the budget: %v", err)
+	}
+}
+
+func TestR2FS_CloseReturnsTheBudget(t *testing.T) {
+	body := []byte("body")
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(int64(len(body)))
+	r.header = stubFSFetcher(&r2Object{Size: int64(len(body))}, nil)
+	r.fetcher = stubFSFetcher(&r2Object{Body: body}, nil)
+
+	file, err := r.Open("site/deploys/v1/index.html")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := file.Read(make([]byte, len(body))); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := r.acquireBudget(ctx, int64(len(body))); err == nil {
+		t.Fatal("an open file must hold its budget")
+	}
+
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := r.acquireBudget(context.Background(), int64(len(body))); err != nil {
+		t.Fatalf("Close must release the budget: %v", err)
+	}
+}
+
+func TestR2FS_OpenAndStatAgreeOnErrorShape(t *testing.T) {
+	cases := []struct {
+		name          string
+		headerErr     error
+		probe         func(context.Context, string) (bool, error)
+		wantNotExist  bool
+		wantPathError bool
+	}{
+		{
+			name:          "missing object",
+			headerErr:     fs.ErrNotExist,
+			probe:         stubIndexProbe(false, nil),
+			wantNotExist:  true,
+			wantPathError: true,
+		},
+		{
+			name:          "upstream failure",
+			headerErr:     errors.New("caddy.fs.r2: upstream 503"),
+			probe:         stubIndexProbe(false, nil),
+			wantNotExist:  false,
+			wantPathError: false,
+		},
+		{
+			name:          "probe failure",
+			headerErr:     fs.ErrNotExist,
+			probe:         stubIndexProbe(false, errors.New("caddy.fs.r2: upstream 503")),
+			wantNotExist:  false,
+			wantPathError: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := newTestR2FS()
+			r.header = stubFSFetcher(nil, c.headerErr)
+			r.indexProbe = c.probe
+
+			_, openErr := r.Open("site/deploys/v1/index.html")
+			_, statErr := r.Stat("site/deploys/v1/index.html")
+			if openErr == nil || statErr == nil {
+				t.Fatalf("both must fail: open=%v stat=%v", openErr, statErr)
+			}
+
+			for label, err := range map[string]error{"Open": openErr, "Stat": statErr} {
+				if got := errors.Is(err, fs.ErrNotExist); got != c.wantNotExist {
+					t.Errorf("%s ErrNotExist: want %v, got %v (%v)", label, c.wantNotExist, got, err)
+				}
+				var pe *fs.PathError
+				if got := errors.As(err, &pe); got != c.wantPathError {
+					t.Errorf("%s PathError: want %v, got %v (%v)", label, c.wantPathError, got, err)
+				}
+			}
+		})
+	}
+}
+
+func TestMetrics_CountR2OperationsAndLookups(t *testing.T) {
+	initMetrics(nil)
+
+	before := testutil.ToFloat64(moduleMetrics.operations.WithLabelValues(opGet, resultNotFound))
+
+	r := newWiredR2FS(t, writeNoSuchKey)
+	if _, err := r.getObject(context.Background(), "site/missing.html"); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("want fs.ErrNotExist, got %v", err)
+	}
+
+	after := testutil.ToFloat64(moduleMetrics.operations.WithLabelValues(opGet, resultNotFound))
+	if after != before+1 {
+		t.Errorf("a missing object must count once: before %v, after %v", before, after)
+	}
+}
+
+func TestMetrics_CountAliasCacheOutcomes(t *testing.T) {
+	initMetrics(nil)
+
+	beforeMiss := testutil.ToFloat64(moduleMetrics.lookups.WithLabelValues(resultMiss))
+	beforeHit := testutil.ToFloat64(moduleMetrics.lookups.WithLabelValues(resultHit))
+
+	cache := newAliasCache(4, time.Minute, time.Second)
+	fetch := func(context.Context, string) (aliasEntry, error) {
+		return aliasEntry{DeployID: "v1", Present: true}, nil
+	}
+	for range 2 {
+		if _, err := cache.Resolve(context.Background(), "b", "site", "production", fetch); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+	}
+
+	if got := testutil.ToFloat64(moduleMetrics.lookups.WithLabelValues(resultMiss)); got != beforeMiss+1 {
+		t.Errorf("miss count: want %v, got %v", beforeMiss+1, got)
+	}
+	if got := testutil.ToFloat64(moduleMetrics.lookups.WithLabelValues(resultHit)); got != beforeHit+1 {
+		t.Errorf("hit count: want %v, got %v", beforeHit+1, got)
+	}
+}
+
+func TestUpstreamStatus_TreatsThrottlingAsUpstream(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	_, err := r.getObject(context.Background(), "site/index.html")
+	if err == nil {
+		t.Fatal("a throttled fetch must fail")
+	}
+	if code, upstream := upstreamStatus(err); !upstream || code != http.StatusTooManyRequests {
+		t.Errorf("429 must classify as upstream, got code=%d upstream=%v (%v)", code, upstream, err)
+	}
+	if got := retryAfterFrom(err); got != "7" {
+		t.Errorf("Retry-After: want R2's own 7, got %q", got)
+	}
+}
+
+func TestSDKLogger_BridgesToZap(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	bridge := sdkLogger{logger: zap.New(core)}
+
+	bridge.Logf(logging.Warn, "checksum %s skipped", "sha256")
+	bridge.Logf(logging.Debug, "attempt %d", 2)
+
+	entries := logs.All()
+	if len(entries) != 2 {
+		t.Fatalf("want 2 structured entries, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.WarnLevel {
+		t.Errorf("an SDK warning must arrive as a warning, got %v", entries[0].Level)
+	}
+	if got := entries[0].ContextMap()["message"]; got != "checksum sha256 skipped" {
+		t.Errorf("message: got %v", got)
+	}
+	if entries[1].Level != zapcore.DebugLevel {
+		t.Errorf("SDK chatter must arrive as debug, got %v", entries[1].Level)
+	}
+}
+
+func TestSDKLogger_ToleratesNoLogger(t *testing.T) {
+	sdkLogger{}.Logf(logging.Warn, "no logger wired yet")
+}
+
+func TestCleanup_ReleasesPooledResources(t *testing.T) {
+	ctx := caddy.Context{Context: context.Background()}
+	cfg := r2ClientConfig{
+		Bucket: "cleanup", Endpoint: "https://cleanup.example", Region: "auto",
+		AccessKeyID: "kid", SecretAccessKey: "sak",
+		UsePathStyle: true, MaxAttempts: 2, MaxBackoff: time.Second,
+	}
+	client, clientKey, err := sharedS3Client(ctx, cfg, zap.NewNop())
+	if err != nil {
+		t.Fatalf("sharedS3Client: %v", err)
+	}
+	cache, cacheKey := sharedAliasCache(cfg.Endpoint, cfg.Bucket, 4, time.Minute, time.Second)
+
+	alias := &R2Alias{client: client, clientKey: clientKey, cache: cache, cacheKey: cacheKey}
+	if err := alias.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	fs := &R2FS{clientKey: clientKey}
+	if err := fs.Cleanup(); err != nil {
+		t.Fatalf("Cleanup with a released key: %v", err)
+	}
+	if err := (&R2FS{}).Cleanup(); err != nil {
+		t.Fatalf("Cleanup before Provision must be a no-op: %v", err)
+	}
+}
+
+func TestR2FS_Validate_RequiresBucketAndEndpoint(t *testing.T) {
+	if err := (&R2FS{Endpoint: "https://r2.example"}).Validate(); err == nil {
+		t.Error("bucket is required")
+	}
+	if err := (&R2FS{Bucket: "b"}).Validate(); err == nil {
+		t.Error("endpoint is required")
+	}
+
+	valid := &R2FS{Bucket: "b", Endpoint: "https://r2.example"}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if valid.UsePathStyle == nil || !*valid.UsePathStyle {
+		t.Error("R2 needs path-style addressing by default")
+	}
+	if valid.MaxInFlightBytes < valid.MaxFileSize {
+		t.Errorf("the in-flight budget %d must hold at least one object of %d",
+			valid.MaxInFlightBytes, valid.MaxFileSize)
+	}
+}

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -480,6 +480,41 @@ func TestR2FS_ReweighBudget_GrowWaitsForAQueueToDrain(t *testing.T) {
 	if elapsed >= budgetGrowWait {
 		t.Errorf("the grow must succeed as soon as the queue clears, took %s", elapsed)
 	}
+	if elapsed < 15*time.Millisecond {
+		t.Errorf("the grow returned before the queue could have cleared, so it never waited: %s", elapsed)
+	}
+}
+
+func TestR2FS_ReweighBudget_CapsConcurrentGrowWaits(t *testing.T) {
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(64)
+	r.growWaits = semaphore.NewWeighted(1)
+
+	if err := r.acquireBudget(context.Background(), 64); err != nil {
+		t.Fatalf("fill the budget: %v", err)
+	}
+
+	waiting := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(waiting)
+		_, _ = r.reweighBudget(1, 32)
+		close(done)
+	}()
+	<-waiting
+
+	deadline := time.Now().Add(budgetGrowWait)
+	for time.Now().Before(deadline) {
+		if _, err := r.reweighBudget(1, 32); err != nil {
+			if !strings.Contains(err.Error(), "already waiting") {
+				continue
+			}
+			<-done
+			return
+		}
+		t.Fatal("the budget is full, so no grow can succeed")
+	}
+	t.Fatal("a second grow must be refused while the cap is taken, not queued behind it")
 }
 
 func TestR2FS_ReweighBudget_GrowReleasesBeforeItWaits(t *testing.T) {
@@ -542,7 +577,9 @@ func TestR2FS_ReweighBudget_GrowGivesUpItsChargeWhenRefused(t *testing.T) {
 	}
 
 	r.releaseBudget(56)
-	if err := r.acquireBudget(context.Background(), 64); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := r.acquireBudget(ctx, 64); err != nil {
 		t.Fatalf("a refused grow must leave its original charge released: %v", err)
 	}
 }

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -448,15 +448,12 @@ func TestR2FS_ReweighBudget_ShrinkSucceedsWhileAWaiterIsQueued(t *testing.T) {
 		t.Fatalf("another request's charge: %v", err)
 	}
 
-	queued := make(chan struct{})
 	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
 	defer cancelWaiter()
-	go func() {
-		close(queued)
-		_ = r.budget.Acquire(waiterCtx, 32)
-	}()
-	<-queued
-	time.Sleep(50 * time.Millisecond)
+	go func() { _ = r.budget.Acquire(waiterCtx, 32) }()
+	for r.budget.TryAcquire(1) {
+		r.budget.Release(1)
+	}
 
 	held, err := r.reweighBudget(8, 4)
 	if err != nil {

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -332,6 +332,26 @@ func TestCleanup_ReleasesPooledResources(t *testing.T) {
 	}
 }
 
+func TestR2FS_Provision_WiresBothLimiters(t *testing.T) {
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	r := &R2FS{Bucket: "b", Endpoint: "https://r2.example", MaxFileSize: 1024}
+	if err := r.Provision(caddy.Context{Context: context.Background()}); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Cleanup() })
+
+	if r.budget == nil {
+		t.Error("Provision must wire the in-flight byte budget")
+	}
+	if r.growWaits == nil {
+		t.Error("Provision must wire the grow-wait cap, or production runs unlimited")
+	}
+	if !r.growWaits.TryAcquire(maxConcurrentGrowWaits) {
+		t.Errorf("the grow-wait cap must start with %d free slots", maxConcurrentGrowWaits)
+	}
+}
+
 func TestR2FS_Validate_RequiresBucketAndEndpoint(t *testing.T) {
 	if err := (&R2FS{Endpoint: "https://r2.example"}).Validate(); err == nil {
 		t.Error("bucket is required")
@@ -514,6 +534,13 @@ func TestR2FS_ReweighBudget_CapsConcurrentGrowWaits(t *testing.T) {
 	if elapsed := time.Since(start); elapsed >= budgetGrowWait {
 		t.Errorf("the refusal must be immediate, took %s", elapsed)
 	}
+
+	r.releaseBudget(63)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := r.acquireBudget(ctx, 64); err != nil {
+		t.Fatalf("a grow refused by the cap must still return its original charge: %v", err)
+	}
 }
 
 func TestR2FS_ReweighBudget_GrowReleasesBeforeItWaits(t *testing.T) {
@@ -574,6 +601,11 @@ func TestR2FS_ReweighBudget_GrowGivesUpItsChargeWhenRefused(t *testing.T) {
 	if held != 0 {
 		t.Errorf("a refused grow must report nothing held, got %d", held)
 	}
+
+	if !r.growWaits.TryAcquire(maxConcurrentGrowWaits) {
+		t.Error("a refused grow must hand its wait slot back, or the cap erodes to nothing")
+	}
+	r.growWaits.Release(maxConcurrentGrowWaits)
 
 	r.releaseBudget(56)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/caddy-r2alias/module_surface_test.go
+++ b/caddy-r2alias/module_surface_test.go
@@ -391,7 +391,15 @@ func TestR2FS_ReweighBudget_ChargesTheDeliveredBody(t *testing.T) {
 	if err := r.acquireBudget(context.Background(), 64); err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
-	held, err = r.reweighBudget(64, 8)
+	held, err = r.reweighBudget(64, 0)
+	if err != nil {
+		t.Fatalf("reweigh to an empty body: %v", err)
+	}
+	if held != 1 {
+		t.Errorf("an empty body still costs one unit, got %d", held)
+	}
+
+	held, err = r.reweighBudget(held, 8)
 	if err != nil {
 		t.Fatalf("reweigh down: %v", err)
 	}
@@ -434,6 +442,108 @@ func TestR2FS_ReweighBudget_NeverStallsOnAContendedBudget(t *testing.T) {
 	defer cancel()
 	if err := r.acquireBudget(ctx, 64); err != nil {
 		t.Fatalf("every charge must be accounted for once the reweighs settle: %v", err)
+	}
+}
+
+func TestR2FS_ReweighBudget_GrowWaitsForAQueueToDrain(t *testing.T) {
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(64)
+
+	if err := r.acquireBudget(context.Background(), 8); err != nil {
+		t.Fatalf("our own charge: %v", err)
+	}
+	if err := r.acquireBudget(context.Background(), 40); err != nil {
+		t.Fatalf("another request's charge: %v", err)
+	}
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	defer cancelWaiter()
+	go func() { _ = r.budget.Acquire(waiterCtx, 60) }()
+	for r.budget.TryAcquire(1) {
+		r.budget.Release(1)
+	}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancelWaiter()
+	}()
+
+	start := time.Now()
+	held, err := r.reweighBudget(8, 16)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("a grow must survive a queue that drains inside the window: %v", err)
+	}
+	if held != 16 {
+		t.Errorf("held: want 16, got %d", held)
+	}
+	if elapsed >= budgetGrowWait {
+		t.Errorf("the grow must succeed as soon as the queue clears, took %s", elapsed)
+	}
+}
+
+func TestR2FS_ReweighBudget_GrowReleasesBeforeItWaits(t *testing.T) {
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(64)
+
+	if err := r.acquireBudget(context.Background(), 8); err != nil {
+		t.Fatalf("our own charge: %v", err)
+	}
+	if err := r.acquireBudget(context.Background(), 40); err != nil {
+		t.Fatalf("another request's charge: %v", err)
+	}
+
+	served := make(chan time.Duration, 1)
+	waiterCtx, cancelWaiter := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelWaiter()
+
+	start := time.Now()
+	go func() {
+		if err := r.budget.Acquire(waiterCtx, 24); err != nil {
+			return
+		}
+		served <- time.Since(start)
+	}()
+	for r.budget.TryAcquire(1) {
+		r.budget.Release(1)
+	}
+
+	if _, err := r.reweighBudget(8, 16); err == nil {
+		t.Fatal("this grow cannot fit once the waiter takes the freed capacity")
+	}
+
+	select {
+	case waited := <-served:
+		if waited >= budgetGrowWait {
+			t.Errorf("the queued waiter should be served the moment the grow returns its charge, waited %s", waited)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("the queued waiter was never served")
+	}
+}
+
+func TestR2FS_ReweighBudget_GrowGivesUpItsChargeWhenRefused(t *testing.T) {
+	r := newTestR2FS()
+	r.budget = semaphore.NewWeighted(64)
+
+	if err := r.acquireBudget(context.Background(), 8); err != nil {
+		t.Fatalf("our own charge: %v", err)
+	}
+	if err := r.acquireBudget(context.Background(), 56); err != nil {
+		t.Fatalf("another request's charge: %v", err)
+	}
+
+	held, err := r.reweighBudget(8, 64)
+	if err == nil {
+		t.Fatal("a grow past the whole budget must fail")
+	}
+	if held != 0 {
+		t.Errorf("a refused grow must report nothing held, got %d", held)
+	}
+
+	r.releaseBudget(56)
+	if err := r.acquireBudget(context.Background(), 64); err != nil {
+		t.Fatalf("a refused grow must leave its original charge released: %v", err)
 	}
 }
 

--- a/caddy-r2alias/pool.go
+++ b/caddy-r2alias/pool.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -98,15 +100,16 @@ func newBudgetedRetryer(maxAttempts int, maxBackoff time.Duration) aws.Retryer {
 	})
 }
 
-func resolvePlaceholders(fields ...*string) error {
+func resolvePlaceholders(fields map[string]*string) error {
 	repl := caddy.NewReplacer()
-	for _, field := range fields {
+	for _, name := range slices.Sorted(maps.Keys(fields)) {
+		field := fields[name]
 		if field == nil || !strings.Contains(*field, "{") {
 			continue
 		}
 		resolved, err := repl.ReplaceOrErr(*field, true, true)
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: unresolved placeholder", name)
 		}
 		*field = resolved
 	}
@@ -141,8 +144,10 @@ func sharedS3Client(ctx caddy.Context, cfg r2ClientConfig, logger *zap.Logger) (
 	return value.(pooledS3Client).client, key, nil
 }
 
-func sharedAliasCache(endpoint, bucket string, size int, ttl, fetchTimeout time.Duration) (*aliasCache, string) {
-	key := fmt.Sprintf("r2-alias-cache-%s-%s-%d-%s-%s", endpoint, bucket, size, ttl, fetchTimeout)
+func sharedAliasCache(cfg r2ClientConfig, size int, ttl, fetchTimeout time.Duration) (*aliasCache, string) {
+	sum := sha256.Sum256([]byte(cfg.poolKey() +
+		strconv.Itoa(size) + ttl.String() + fetchTimeout.String()))
+	key := "r2-alias-cache-" + hex.EncodeToString(sum[:])
 	value, _, _ := aliasCaches.LoadOrNew(key, func() (caddy.Destructor, error) {
 		return pooledAliasCache{cache: newAliasCache(size, ttl, fetchTimeout)}, nil
 	})

--- a/caddy-r2alias/pool.go
+++ b/caddy-r2alias/pool.go
@@ -1,0 +1,150 @@
+package r2alias
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go/logging"
+	"github.com/caddyserver/caddy/v2"
+	"go.uber.org/zap"
+)
+
+var (
+	s3Clients   = caddy.NewUsagePool()
+	aliasCaches = caddy.NewUsagePool()
+)
+
+type r2ClientConfig struct {
+	Bucket          string
+	Endpoint        string
+	Region          string
+	AccessKeyID     string
+	SecretAccessKey string
+	UsePathStyle    bool
+	MaxAttempts     int
+	MaxBackoff      time.Duration
+}
+
+func (c r2ClientConfig) poolKey() string {
+	sum := sha256.Sum256([]byte(strconv.Quote(c.Bucket) +
+		strconv.Quote(c.Endpoint) +
+		strconv.Quote(c.Region) +
+		strconv.Quote(c.AccessKeyID) +
+		strconv.Quote(c.SecretAccessKey) +
+		strconv.FormatBool(c.UsePathStyle) +
+		strconv.Itoa(c.MaxAttempts) +
+		c.MaxBackoff.String()))
+	return "r2-client-" + hex.EncodeToString(sum[:])
+}
+
+type pooledS3Client struct {
+	client *s3.Client
+}
+
+func (pooledS3Client) Destruct() error { return nil }
+
+type pooledAliasCache struct {
+	cache *aliasCache
+}
+
+// https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L79-L80
+func (p pooledAliasCache) Destruct() error {
+	p.cache.lru.Purge()
+	return nil
+}
+
+type sdkLogger struct {
+	logger *zap.Logger
+}
+
+func (l sdkLogger) Logf(classification logging.Classification, format string, v ...any) {
+	if l.logger == nil {
+		return
+	}
+	msg := fmt.Sprintf(format, v...)
+	if classification == logging.Warn {
+		l.logger.Warn("aws sdk", zap.String("message", msg))
+		return
+	}
+	l.logger.Debug("aws sdk", zap.String("message", msg))
+}
+
+func newBudgetedRetryer(maxAttempts int, maxBackoff time.Duration) aws.Retryer {
+	codes := make(map[int]struct{}, len(awsretry.DefaultRetryableHTTPStatusCodes)+1)
+	for code := range awsretry.DefaultRetryableHTTPStatusCodes {
+		codes[code] = struct{}{}
+	}
+	codes[http.StatusTooManyRequests] = struct{}{}
+
+	return awsretry.NewStandard(func(o *awsretry.StandardOptions) {
+		o.MaxAttempts = maxAttempts
+		o.MaxBackoff = maxBackoff
+		o.Retryables = append([]awsretry.IsErrorRetryable(nil), awsretry.DefaultRetryables...)
+		for i, retryable := range o.Retryables {
+			if _, ok := retryable.(awsretry.RetryableHTTPStatusCode); ok {
+				o.Retryables[i] = awsretry.RetryableHTTPStatusCode{Codes: codes}
+			}
+		}
+	})
+}
+
+func resolvePlaceholders(fields ...*string) error {
+	repl := caddy.NewReplacer()
+	for _, field := range fields {
+		if field == nil || !strings.Contains(*field, "{") {
+			continue
+		}
+		resolved, err := repl.ReplaceOrErr(*field, true, true)
+		if err != nil {
+			return err
+		}
+		*field = resolved
+	}
+	return nil
+}
+
+func sharedS3Client(ctx caddy.Context, cfg r2ClientConfig, logger *zap.Logger) (*s3.Client, string, error) {
+	key := cfg.poolKey()
+	value, _, err := s3Clients.LoadOrNew(key, func() (caddy.Destructor, error) {
+		awsCfg, loadErr := config.LoadDefaultConfig(ctx,
+			config.WithRegion(cfg.Region),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+				cfg.AccessKeyID, cfg.SecretAccessKey, "",
+			)),
+			config.WithLogger(sdkLogger{logger: logger}),
+			config.WithRetryer(func() aws.Retryer {
+				return newBudgetedRetryer(cfg.MaxAttempts, cfg.MaxBackoff)
+			}),
+		)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		return pooledS3Client{client: s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(cfg.Endpoint)
+			o.UsePathStyle = cfg.UsePathStyle
+			o.DisableLogOutputChecksumValidationSkipped = true
+		})}, nil
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return value.(pooledS3Client).client, key, nil
+}
+
+func sharedAliasCache(endpoint, bucket string, size int, ttl, fetchTimeout time.Duration) (*aliasCache, string) {
+	key := fmt.Sprintf("r2-alias-cache-%s-%s-%d-%s-%s", endpoint, bucket, size, ttl, fetchTimeout)
+	value, _, _ := aliasCaches.LoadOrNew(key, func() (caddy.Destructor, error) {
+		return pooledAliasCache{cache: newAliasCache(size, ttl, fetchTimeout)}, nil
+	})
+	return value.(pooledAliasCache).cache, key
+}

--- a/caddy-r2alias/r2alias.go
+++ b/caddy-r2alias/r2alias.go
@@ -125,17 +125,24 @@ func (r *R2Alias) applyDefaults() {
 func (r *R2Alias) Provision(ctx caddy.Context) error {
 	r.applyDefaults()
 	r.logger = ctx.Logger()
-	initMetrics(ctx.GetMetricsRegistry())
+	if err := initMetrics(ctx.GetMetricsRegistry()); err != nil {
+		return fmt.Errorf("r2_alias: %w", err)
+	}
 
-	if err := resolvePlaceholders(
-		&r.Bucket, &r.Endpoint, &r.Region, &r.AccessKeyID, &r.SecretAccessKey,
-		&r.RootDomain, &r.PreviewSubdomain,
-	); err != nil {
+	if err := resolvePlaceholders(map[string]*string{
+		"bucket":            &r.Bucket,
+		"endpoint":          &r.Endpoint,
+		"region":            &r.Region,
+		"access_key_id":     &r.AccessKeyID,
+		"secret_access_key": &r.SecretAccessKey,
+		"root_domain":       &r.RootDomain,
+		"preview_subdomain": &r.PreviewSubdomain,
+	}); err != nil {
 		return fmt.Errorf("r2_alias: %w", err)
 	}
 
 	fetchTimeout := time.Duration(r.FetchTimeout)
-	client, clientKey, err := sharedS3Client(ctx, r2ClientConfig{
+	clientCfg := r2ClientConfig{
 		Bucket:          r.Bucket,
 		Endpoint:        r.Endpoint,
 		Region:          r.Region,
@@ -144,14 +151,15 @@ func (r *R2Alias) Provision(ctx caddy.Context) error {
 		UsePathStyle:    true,
 		MaxAttempts:     aliasRetryAttempts,
 		MaxBackoff:      fetchTimeout / 4,
-	}, r.logger)
+	}
+	client, clientKey, err := sharedS3Client(ctx, clientCfg, r.logger)
 	if err != nil {
 		return fmt.Errorf("r2_alias: load aws config: %w", err)
 	}
 	r.client, r.clientKey = client, clientKey
 
 	r.cache, r.cacheKey = sharedAliasCache(
-		r.Endpoint, r.Bucket, r.CacheMaxEntries, time.Duration(r.CacheTTL), fetchTimeout)
+		clientCfg, r.CacheMaxEntries, time.Duration(r.CacheTTL), fetchTimeout)
 
 	if r.fetcher == nil {
 		r.fetcher = r.fetchAlias

--- a/caddy-r2alias/r2alias.go
+++ b/caddy-r2alias/r2alias.go
@@ -11,13 +11,12 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -38,31 +37,36 @@ const maxAliasBodyBytes = 1024
 
 const (
 	defaultCacheMaxEntries  = 10000
-	defaultCacheTTL         = 15 * time.Second
-	defaultFetchTimeout     = 2 * time.Second
+	defaultCacheTTL         = caddy.Duration(15 * time.Second)
+	defaultFetchTimeout     = caddy.Duration(2 * time.Second)
 	defaultRegion           = "auto"
 	defaultPreviewSubdomain = "preview"
 	defaultRootDomain       = "freecode.camp"
 	defaultDeployIDRegex    = `^[A-Za-z0-9._-]{1,64}$`
+	defaultRetryAfter       = "30"
 )
 
+const aliasRetryAttempts = 2
+
 type R2Alias struct {
-	Bucket           string        `json:"bucket"`
-	Endpoint         string        `json:"endpoint"`
-	Region           string        `json:"region"`
-	AccessKeyID      string        `json:"access_key_id,omitempty"`
-	SecretAccessKey  string        `json:"secret_access_key,omitempty"`
-	CacheTTL         time.Duration `json:"cache_ttl,omitempty"`
-	CacheMaxEntries  int           `json:"cache_max_entries,omitempty"`
-	PreviewSubdomain string        `json:"preview_subdomain,omitempty"`
-	RootDomain       string        `json:"root_domain,omitempty"`
-	DeployIDRegex    string        `json:"deploy_id_regex,omitempty"`
+	Bucket           string         `json:"bucket"`
+	Endpoint         string         `json:"endpoint"`
+	Region           string         `json:"region"`
+	AccessKeyID      string         `json:"access_key_id,omitempty"`
+	SecretAccessKey  string         `json:"secret_access_key,omitempty"`
+	CacheTTL         caddy.Duration `json:"cache_ttl,omitempty"`
+	CacheMaxEntries  int            `json:"cache_max_entries,omitempty"`
+	PreviewSubdomain string         `json:"preview_subdomain,omitempty"`
+	RootDomain       string         `json:"root_domain,omitempty"`
+	DeployIDRegex    string         `json:"deploy_id_regex,omitempty"`
 	// FetchTimeout is read once, by Provision, when it builds the cache. Setting
 	// it on a live handler does nothing; rebuild the cache to change it.
-	FetchTimeout time.Duration `json:"fetch_timeout,omitempty"`
+	FetchTimeout caddy.Duration `json:"fetch_timeout,omitempty"`
 
 	client     *s3.Client
+	clientKey  string
 	cache      *aliasCache
+	cacheKey   string
 	logger     *zap.Logger
 	deployIDRe *regexp.Regexp
 
@@ -81,6 +85,7 @@ type aliasEntry struct {
 func init() {
 	caddy.RegisterModule(R2Alias{})
 	httpcaddyfile.RegisterHandlerDirective("r2_alias", parseCaddyfile)
+	httpcaddyfile.RegisterDirectiveOrder("r2_alias", httpcaddyfile.Before, "file_server")
 }
 
 func (R2Alias) CaddyModule() caddy.ModuleInfo {
@@ -119,27 +124,54 @@ func (r *R2Alias) applyDefaults() {
 
 func (r *R2Alias) Provision(ctx caddy.Context) error {
 	r.applyDefaults()
+	r.logger = ctx.Logger()
+	initMetrics(ctx.GetMetricsRegistry())
 
-	awsCfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(r.Region),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			r.AccessKeyID, r.SecretAccessKey, "",
-		)),
-	)
+	if err := resolvePlaceholders(
+		&r.Bucket, &r.Endpoint, &r.Region, &r.AccessKeyID, &r.SecretAccessKey,
+		&r.RootDomain, &r.PreviewSubdomain,
+	); err != nil {
+		return fmt.Errorf("r2_alias: %w", err)
+	}
+
+	fetchTimeout := time.Duration(r.FetchTimeout)
+	client, clientKey, err := sharedS3Client(ctx, r2ClientConfig{
+		Bucket:          r.Bucket,
+		Endpoint:        r.Endpoint,
+		Region:          r.Region,
+		AccessKeyID:     r.AccessKeyID,
+		SecretAccessKey: r.SecretAccessKey,
+		UsePathStyle:    true,
+		MaxAttempts:     aliasRetryAttempts,
+		MaxBackoff:      fetchTimeout / 4,
+	}, r.logger)
 	if err != nil {
 		return fmt.Errorf("r2_alias: load aws config: %w", err)
 	}
-	r.client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
-		o.BaseEndpoint = aws.String(r.Endpoint)
-		o.UsePathStyle = true
-	})
+	r.client, r.clientKey = client, clientKey
 
-	r.cache = newAliasCache(r.CacheMaxEntries, r.CacheTTL, r.FetchTimeout)
-	r.logger = ctx.Logger()
+	r.cache, r.cacheKey = sharedAliasCache(
+		r.Endpoint, r.Bucket, r.CacheMaxEntries, time.Duration(r.CacheTTL), fetchTimeout)
+
 	if r.fetcher == nil {
 		r.fetcher = r.fetchAlias
 	}
 	return nil
+}
+
+func (r *R2Alias) Cleanup() error {
+	var errs []error
+	if r.clientKey != "" {
+		if _, err := s3Clients.Delete(r.clientKey); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if r.cacheKey != "" {
+		if _, err := aliasCaches.Delete(r.cacheKey); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (r *R2Alias) Validate() error {
@@ -153,13 +185,13 @@ func (r *R2Alias) Validate() error {
 	r.applyDefaults()
 
 	if r.CacheTTL <= 0 {
-		return fmt.Errorf("r2_alias: cache_ttl must be > 0 (got %s)", r.CacheTTL)
+		return fmt.Errorf("r2_alias: cache_ttl must be > 0 (got %s)", time.Duration(r.CacheTTL))
 	}
 	if r.CacheMaxEntries <= 0 {
 		return fmt.Errorf("r2_alias: cache_max_entries must be > 0 (got %d)", r.CacheMaxEntries)
 	}
 	if r.FetchTimeout <= 0 {
-		return fmt.Errorf("r2_alias: fetch_timeout must be > 0 (got %s)", r.FetchTimeout)
+		return fmt.Errorf("r2_alias: fetch_timeout must be > 0 (got %s)", time.Duration(r.FetchTimeout))
 	}
 
 	re, err := regexp.Compile(r.DeployIDRegex)
@@ -202,8 +234,8 @@ func (r *R2Alias) ServeHTTP(w http.ResponseWriter, req *http.Request, next caddy
 		// it answers 503 with Retry-After like any other upstream failure.
 		if errors.Is(resolveErr, errS3ServerError) ||
 			errors.Is(resolveErr, context.DeadlineExceeded) {
-			w.Header().Set("Retry-After", "30")
-			r.logger.Error("r2_alias upstream 5xx", fields...)
+			w.Header().Set("Retry-After", retryAfterFrom(resolveErr))
+			r.logger.Error("r2_alias upstream unavailable", fields...)
 			return caddyhttp.Error(http.StatusServiceUnavailable, resolveErr)
 		}
 		r.logger.Error("r2_alias resolve error", fields...)
@@ -226,6 +258,8 @@ func (r *R2Alias) ServeHTTP(w http.ResponseWriter, req *http.Request, next caddy
 		return caddyhttp.Error(http.StatusNotFound, fmt.Errorf("r2_alias: deploy id rejected"))
 	}
 
+	w.Header().Set("Etag", strconv.Quote(entry.DeployID))
+
 	// Clean before the join: Caddy leaves req.URL.Path raw, and file_server's
 	// SanitizedPathJoin cleans too late to keep `..` inside the deploy prefix.
 	origPath := caddyhttp.CleanPath("/"+req.URL.Path, true)
@@ -233,6 +267,25 @@ func (r *R2Alias) ServeHTTP(w http.ResponseWriter, req *http.Request, next caddy
 	req.URL.RawPath = ""
 
 	return next.ServeHTTP(w, req)
+}
+
+func upstreamStatus(err error) (int, bool) {
+	var respErr *awshttp.ResponseError
+	if !errors.As(err, &respErr) {
+		return 0, false
+	}
+	code := respErr.HTTPStatusCode()
+	return code, code >= 500 || code == http.StatusTooManyRequests
+}
+
+func retryAfterFrom(err error) string {
+	var respErr *awshttp.ResponseError
+	if errors.As(err, &respErr) && respErr.Response != nil && respErr.Response.Response != nil {
+		if after := respErr.Response.Header.Get("Retry-After"); after != "" {
+			return after
+		}
+	}
+	return defaultRetryAfter
 }
 
 func (r *R2Alias) fetchAlias(ctx context.Context, cacheKey string) (aliasEntry, error) {
@@ -248,14 +301,16 @@ func (r *R2Alias) fetchAlias(ctx context.Context, cacheKey string) (aliasEntry, 
 	})
 	if err != nil {
 		if isNoSuchKey(err) {
+			recordOperation(opAlias, resultNotFound)
 			return aliasEntry{Present: false}, nil
 		}
-		var respErr *awshttp.ResponseError
-		if errors.As(err, &respErr) && respErr.HTTPStatusCode() >= 500 {
+		recordOperation(opAlias, resultError)
+		if _, upstream := upstreamStatus(err); upstream {
 			return aliasEntry{}, fmt.Errorf("%w: %w", errS3ServerError, err)
 		}
 		return aliasEntry{}, fmt.Errorf("r2_alias: s3 GetObject %s: %w", s3Key, err)
 	}
+	recordOperation(opAlias, resultOK)
 	defer func() { _ = out.Body.Close() }()
 
 	body, readErr := io.ReadAll(io.LimitReader(out.Body, maxAliasBodyBytes))
@@ -273,6 +328,7 @@ func (r *R2Alias) fetchAlias(ctx context.Context, cacheKey string) (aliasEntry, 
 var (
 	_ caddy.Provisioner           = (*R2Alias)(nil)
 	_ caddy.Validator             = (*R2Alias)(nil)
+	_ caddy.CleanerUpper          = (*R2Alias)(nil)
 	_ caddyfile.Unmarshaler       = (*R2Alias)(nil)
 	_ caddyhttp.MiddlewareHandler = (*R2Alias)(nil)
 )

--- a/caddy-r2alias/r2alias_test.go
+++ b/caddy-r2alias/r2alias_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"go.uber.org/zap"
@@ -45,14 +46,14 @@ func TestValidate_DefaultsApplied(t *testing.T) {
 	if r.Region != "auto" {
 		t.Errorf("Region default: want \"auto\", got %q", r.Region)
 	}
-	if r.CacheTTL != 15*time.Second {
-		t.Errorf("CacheTTL default: want 15s, got %s", r.CacheTTL)
+	if time.Duration(r.CacheTTL) != 15*time.Second {
+		t.Errorf("CacheTTL default: want 15s, got %s", time.Duration(r.CacheTTL))
 	}
 	if r.CacheMaxEntries != 10000 {
 		t.Errorf("CacheMaxEntries default: want 10000, got %d", r.CacheMaxEntries)
 	}
-	if r.FetchTimeout != 2*time.Second {
-		t.Errorf("FetchTimeout default: want 2s, got %s", r.FetchTimeout)
+	if time.Duration(r.FetchTimeout) != 2*time.Second {
+		t.Errorf("FetchTimeout default: want 2s, got %s", time.Duration(r.FetchTimeout))
 	}
 	if r.PreviewSubdomain != "preview" {
 		t.Errorf("PreviewSubdomain default: want \"preview\", got %q", r.PreviewSubdomain)
@@ -77,7 +78,7 @@ func TestValidate_NegativeCacheParams(t *testing.T) {
 	}{
 		{
 			"negative CacheTTL",
-			R2Alias{Bucket: "b", Endpoint: "https://x", CacheTTL: -1 * time.Second},
+			R2Alias{Bucket: "b", Endpoint: "https://x", CacheTTL: caddy.Duration(-1 * time.Second)},
 			"cache_ttl must be > 0",
 		},
 		{
@@ -87,7 +88,7 @@ func TestValidate_NegativeCacheParams(t *testing.T) {
 		},
 		{
 			"negative FetchTimeout",
-			R2Alias{Bucket: "b", Endpoint: "https://x", FetchTimeout: -1 * time.Second},
+			R2Alias{Bucket: "b", Endpoint: "https://x", FetchTimeout: caddy.Duration(-1 * time.Second)},
 			"fetch_timeout must be > 0",
 		},
 	}
@@ -138,14 +139,14 @@ func TestUnmarshalCaddyfile_FullBlock(t *testing.T) {
 	if r.AccessKeyID != "k" || r.SecretAccessKey != "s" {
 		t.Errorf("creds mismatch: %+v", r)
 	}
-	if r.CacheTTL != 15*time.Second {
-		t.Errorf("CacheTTL: want 15s, got %s", r.CacheTTL)
+	if time.Duration(r.CacheTTL) != 15*time.Second {
+		t.Errorf("CacheTTL: want 15s, got %s", time.Duration(r.CacheTTL))
 	}
 	if r.CacheMaxEntries != 10000 {
 		t.Errorf("CacheMaxEntries: want 10000, got %d", r.CacheMaxEntries)
 	}
-	if r.FetchTimeout != 2*time.Second {
-		t.Errorf("FetchTimeout: want 2s, got %s", r.FetchTimeout)
+	if time.Duration(r.FetchTimeout) != 2*time.Second {
+		t.Errorf("FetchTimeout: want 2s, got %s", time.Duration(r.FetchTimeout))
 	}
 	if r.PreviewSubdomain != "preview" {
 		t.Errorf("PreviewSubdomain mismatch: %q", r.PreviewSubdomain)
@@ -195,13 +196,13 @@ func newProvisionedForTest(t *testing.T) *R2Alias {
 		RootDomain:       "freecode.camp",
 		PreviewSubdomain: "preview",
 		DeployIDRegex:    `^[A-Za-z0-9._-]{1,64}$`,
-		CacheTTL:         1 * time.Second,
+		CacheTTL:         caddy.Duration(1 * time.Second),
 		CacheMaxEntries:  10,
 		FetchTimeout:     defaultFetchTimeout,
 		logger:           zap.NewNop(),
 	}
 	r.deployIDRe = regexp.MustCompile(r.DeployIDRegex)
-	r.cache = newAliasCache(r.CacheMaxEntries, r.CacheTTL, r.FetchTimeout)
+	r.cache = newAliasCache(r.CacheMaxEntries, time.Duration(r.CacheTTL), time.Duration(r.FetchTimeout))
 	return r
 }
 
@@ -237,8 +238,8 @@ func blockingFetcher(ctx context.Context, _ string) (aliasEntry, error) {
 func newProvisionedWithFetchTimeout(t *testing.T, d time.Duration) *R2Alias {
 	t.Helper()
 	r := newProvisionedForTest(t)
-	r.FetchTimeout = d
-	r.cache = newAliasCache(r.CacheMaxEntries, r.CacheTTL, r.FetchTimeout)
+	r.FetchTimeout = caddy.Duration(d)
+	r.cache = newAliasCache(r.CacheMaxEntries, time.Duration(r.CacheTTL), time.Duration(r.FetchTimeout))
 	return r
 }
 

--- a/caddy-r2alias/s3ops_test.go
+++ b/caddy-r2alias/s3ops_test.go
@@ -150,7 +150,7 @@ func TestGetObject_ServerErrorIsAnUpstreamFailure(t *testing.T) {
 	if errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("a 500 must not read as missing, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "upstream 5xx") {
+	if !strings.Contains(err.Error(), "upstream 5") {
 		t.Errorf("error should name the upstream failure, got %v", err)
 	}
 }
@@ -187,7 +187,7 @@ func TestHeadObject_ServerErrorIsAnUpstreamFailure(t *testing.T) {
 	})
 
 	_, err := r.headObject(context.Background(), "site/index.html")
-	if err == nil || !strings.Contains(err.Error(), "upstream 5xx") {
+	if err == nil || !strings.Contains(err.Error(), "upstream 5") {
 		t.Fatalf("error should name the upstream failure, got %v", err)
 	}
 }

--- a/caddy-r2alias/s3ops_test.go
+++ b/caddy-r2alias/s3ops_test.go
@@ -1,0 +1,237 @@
+package r2alias
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.uber.org/zap"
+)
+
+const testMaxFileSize int64 = 1024
+
+func newWiredR2FS(t *testing.T, handler http.HandlerFunc) *R2FS {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	r := &R2FS{
+		Bucket:      "test-bucket",
+		Endpoint:    srv.URL,
+		Region:      "auto",
+		MaxFileSize: testMaxFileSize,
+		logger:      zap.NewNop(),
+	}
+	r.client = s3.NewFromConfig(aws.Config{
+		Region: "auto",
+		Credentials: credentials.NewStaticCredentialsProvider(
+			"test", "test", ""),
+	}, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(srv.URL)
+		o.UsePathStyle = true
+	})
+	return r
+}
+
+func writeNoSuchKey(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusNotFound)
+	if req.Method == http.MethodHead {
+		return
+	}
+	fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+		`<Error><Code>NoSuchKey</Code><Message>no such key</Message></Error>`)
+}
+
+func TestGetObject_ServesTheBody(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Length", "4")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("okay"))
+	})
+
+	obj, err := r.getObject(context.Background(), "site/index.html")
+	if err != nil {
+		t.Fatalf("getObject: %v", err)
+	}
+	if string(obj.Body) != "okay" {
+		t.Errorf("body: want %q, got %q", "okay", obj.Body)
+	}
+	if obj.Size != 4 {
+		t.Errorf("size: want 4, got %d", obj.Size)
+	}
+	if obj.ContentType != "text/html" {
+		t.Errorf("content type: want text/html, got %q", obj.ContentType)
+	}
+}
+
+func TestGetObject_RejectsADeclaredOversizeObject(t *testing.T) {
+	t.Parallel()
+	oversize := strings.Repeat("x", int(testMaxFileSize)+1)
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(oversize)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(oversize))
+	})
+
+	_, err := r.getObject(context.Background(), "site/big.bin")
+	if !errors.Is(err, errObjectTooLarge) {
+		t.Fatalf("want errObjectTooLarge, got %v", err)
+	}
+}
+
+func TestGetObject_RejectsAnUndeclaredOversizeStream(t *testing.T) {
+	t.Parallel()
+	oversize := strings.Repeat("x", int(testMaxFileSize)*4)
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(oversize))
+	})
+
+	_, err := r.getObject(context.Background(), "site/chunked.bin")
+	if !errors.Is(err, errObjectTooLarge) {
+		t.Fatalf("an object with no declared length must not truncate silently, got %v", err)
+	}
+}
+
+func TestGetObject_AbortedStreamFailsTheFetch(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "64")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("half"))
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
+	})
+
+	_, err := r.getObject(context.Background(), "site/truncated.html")
+	if err == nil {
+		t.Fatal("a stream that dies mid-body must fail the fetch")
+	}
+	if !strings.Contains(err.Error(), "read body") {
+		t.Errorf("error should name the read failure, got %v", err)
+	}
+}
+
+func TestGetObject_MissingKeyIsErrNotExist(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, writeNoSuchKey)
+
+	_, err := r.getObject(context.Background(), "site/missing.html")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("want fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestGetObject_ServerErrorIsAnUpstreamFailure(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := r.getObject(context.Background(), "site/index.html")
+	if err == nil {
+		t.Fatal("a 500 must fail the fetch")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("a 500 must not read as missing, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "upstream 5xx") {
+		t.Errorf("error should name the upstream failure, got %v", err)
+	}
+}
+
+func TestGetObject_ClientErrorIsNotMissing(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	_, err := r.getObject(context.Background(), "site/index.html")
+	if err == nil {
+		t.Fatal("a 403 must fail the fetch")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("a 403 must not read as missing, got %v", err)
+	}
+}
+
+func TestHeadObject_MissingKeyIsErrNotExist(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, writeNoSuchKey)
+
+	_, err := r.headObject(context.Background(), "site/missing.html")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("want fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestHeadObject_ServerErrorIsAnUpstreamFailure(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	_, err := r.headObject(context.Background(), "site/index.html")
+	if err == nil || !strings.Contains(err.Error(), "upstream 5xx") {
+		t.Fatalf("error should name the upstream failure, got %v", err)
+	}
+}
+
+func TestHeadObject_ClientErrorIsNotMissing(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	_, err := r.headObject(context.Background(), "site/index.html")
+	if err == nil {
+		t.Fatal("a 403 must fail the head")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("a 403 must not read as missing, got %v", err)
+	}
+}
+
+func TestHasIndex_PropagatesAnUpstreamFailure(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := r.hasIndex(context.Background(), "site/deploys/v1"); err == nil {
+		t.Fatal("an upstream failure during the index probe must not read as absent")
+	}
+}
+
+func TestHasIndex_ReportsAPresentIndex(t *testing.T) {
+	t.Parallel()
+	r := newWiredR2FS(t, func(w http.ResponseWriter, req *http.Request) {
+		if !strings.HasSuffix(req.URL.Path, "/"+indexFile) {
+			writeNoSuchKey(w, req)
+			return
+		}
+		w.Header().Set("Content-Length", "10")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	has, err := r.hasIndex(context.Background(), "site/deploys/v1")
+	if err != nil {
+		t.Fatalf("hasIndex: %v", err)
+	}
+	if !has {
+		t.Error("hasIndex should report the index present")
+	}
+}

--- a/caddy-r2alias/s3ops_test.go
+++ b/caddy-r2alias/s3ops_test.go
@@ -79,16 +79,18 @@ func TestGetObject_ServesTheBody(t *testing.T) {
 
 func TestGetObject_RejectsADeclaredOversizeObject(t *testing.T) {
 	t.Parallel()
-	oversize := strings.Repeat("x", int(testMaxFileSize)+1)
+	const withinLimit = "small"
 	r := newWiredR2FS(t, func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Length", strconv.Itoa(len(oversize)))
+		w.Header().Set("Content-Length", strconv.FormatInt(testMaxFileSize+1, 10))
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(oversize))
+		_, _ = w.Write([]byte(withinLimit))
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
 	})
 
 	_, err := r.getObject(context.Background(), "site/big.bin")
 	if !errors.Is(err, errObjectTooLarge) {
-		t.Fatalf("want errObjectTooLarge, got %v", err)
+		t.Fatalf("the declared length alone must reject before any read, got %v", err)
 	}
 }
 

--- a/caddy-r2alias/s3stub_test.go
+++ b/caddy-r2alias/s3stub_test.go
@@ -29,6 +29,7 @@ type s3Stub struct {
 	objects    map[string]stubObject
 	failStatus int
 	failGet    map[string]int
+	failAll    map[string]int
 	requests   []string
 }
 
@@ -38,6 +39,7 @@ func startS3Stub(t *testing.T) *s3Stub {
 		bucket:  testBucket,
 		objects: make(map[string]stubObject),
 		failGet: make(map[string]int),
+		failAll: make(map[string]int),
 	}
 	s.server = httptest.NewServer(http.HandlerFunc(s.serve))
 	t.Cleanup(s.server.Close)
@@ -77,6 +79,12 @@ func (s *s3Stub) failGetForKeyOnly(key string, status int) {
 	s.failGet[key] = status
 }
 
+func (s *s3Stub) failEveryMethodForKeyOnly(key string, status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failAll[key] = status
+}
+
 func (s *s3Stub) putAlias(site, aliasName, deployID string) {
 	s.put(site+"/"+aliasName, deployID, "text/plain")
 }
@@ -108,11 +116,16 @@ func (s *s3Stub) serve(w http.ResponseWriter, req *http.Request) {
 	s.requests = append(s.requests, req.Method+" "+key)
 	fail := s.failStatus
 	getFail := s.failGet[key]
+	allFail := s.failAll[key]
 	obj, found := s.objects[key]
 	s.mu.Unlock()
 
 	if fail != 0 {
 		w.WriteHeader(fail)
+		return
+	}
+	if allFail != 0 {
+		w.WriteHeader(allFail)
 		return
 	}
 	if getFail != 0 && req.Method == http.MethodGet {

--- a/caddy-r2alias/s3stub_test.go
+++ b/caddy-r2alias/s3stub_test.go
@@ -28,12 +28,17 @@ type s3Stub struct {
 	mu         sync.RWMutex
 	objects    map[string]stubObject
 	failStatus int
+	failGet    map[string]int
 	requests   []string
 }
 
 func startS3Stub(t *testing.T) *s3Stub {
 	t.Helper()
-	s := &s3Stub{bucket: testBucket, objects: make(map[string]stubObject)}
+	s := &s3Stub{
+		bucket:  testBucket,
+		objects: make(map[string]stubObject),
+		failGet: make(map[string]int),
+	}
 	s.server = httptest.NewServer(http.HandlerFunc(s.serve))
 	t.Cleanup(s.server.Close)
 	return s
@@ -66,6 +71,12 @@ func (s *s3Stub) setFailure(status int) {
 	s.failStatus = status
 }
 
+func (s *s3Stub) failGetForKeyOnly(key string, status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failGet[key] = status
+}
+
 func (s *s3Stub) putAlias(site, aliasName, deployID string) {
 	s.put(site+"/"+aliasName, deployID, "text/plain")
 }
@@ -96,11 +107,16 @@ func (s *s3Stub) serve(w http.ResponseWriter, req *http.Request) {
 	s.mu.Lock()
 	s.requests = append(s.requests, req.Method+" "+key)
 	fail := s.failStatus
+	getFail := s.failGet[key]
 	obj, found := s.objects[key]
 	s.mu.Unlock()
 
 	if fail != 0 {
 		w.WriteHeader(fail)
+		return
+	}
+	if getFail != 0 && req.Method == http.MethodGet {
+		w.WriteHeader(getFail)
 		return
 	}
 	if !ok {

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
@@ -13,9 +13,7 @@ data:
 
       order r2_alias before file_server
 
-      servers {
-        metrics
-      }
+      metrics
 
       filesystem r2 r2 {
         bucket            {env.R2_BUCKET}
@@ -24,7 +22,8 @@ data:
         access_key_id     {env.AWS_ACCESS_KEY_ID}
         secret_access_key {env.AWS_SECRET_ACCESS_KEY}
         use_path_style
-        max_file_size     33554432
+        max_file_size        33554432
+        max_in_flight_bytes  100663296
         # Code defaults, not set here. Truth lives in the named constants in
         # caddy-r2alias/filesystem.go.
         #   (no knob)      30s      opTimeout, bounds every S3 round trip
@@ -41,7 +40,7 @@ data:
         format json
       }
 
-      @apex host freecode.camp www.freecode.camp
+      @apex host freecode.camp www.freecode.camp freecode.camp. www.freecode.camp.
       handle @apex {
         redir https://www.freecodecamp.org{uri} 302
       }

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
@@ -43,29 +43,36 @@ data:
         respond "ok" 200
       }
 
-      r2_alias {
-        bucket            {$R2_BUCKET}
-        endpoint          {$R2_ENDPOINT}
-        region            auto
-        access_key_id     {$AWS_ACCESS_KEY_ID}
-        secret_access_key {$AWS_SECRET_ACCESS_KEY}
-        cache_ttl         15s
-        cache_max_entries 10000
-        # Code defaults, not set here. Truth lives in the named constants in
-        # caddy-r2alias/r2alias.go; grep them before trusting these numbers.
-        #   fetch_timeout    2s                      defaultFetchTimeout
-        #   deploy_id_regex  ^[A-Za-z0-9._-]{1,64}$  defaultDeployIDRegex
-        # These are comments, not directives. An image that predates a
-        # directive refuses to start and takes every site down.
-        preview_subdomain "preview"
-        root_domain       "freecode.camp"
-      }
+      handle {
+        # https://developers.cloudflare.com/cache/how-to/edge-browser-cache-ttl/
+        header Cache-Control "public, max-age=0, must-revalidate, s-maxage=86400"
 
-      file_server {
-        fs r2
+        r2_alias {
+          bucket            {$R2_BUCKET}
+          endpoint          {$R2_ENDPOINT}
+          region            auto
+          access_key_id     {$AWS_ACCESS_KEY_ID}
+          secret_access_key {$AWS_SECRET_ACCESS_KEY}
+          cache_ttl         15s
+          cache_max_entries 10000
+          # Code defaults, not set here. Truth lives in the named constants in
+          # caddy-r2alias/r2alias.go; grep them before trusting these numbers.
+          #   fetch_timeout    2s                      defaultFetchTimeout
+          #   deploy_id_regex  ^[A-Za-z0-9._-]{1,64}$  defaultDeployIDRegex
+          # These are comments, not directives. An image that predates a
+          # directive refuses to start and takes every site down.
+          preview_subdomain "preview"
+          root_domain       "freecode.camp"
+        }
+
+        file_server {
+          fs r2
+        }
       }
 
       handle_errors {
+        header Cache-Control "no-store"
+
         @404 expression {err.status_code} == 404
         respond @404 "Not Found" 404
 

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
@@ -13,18 +13,26 @@ data:
 
       order r2_alias before file_server
 
+      servers {
+        metrics
+      }
+
       filesystem r2 r2 {
-        bucket            {$R2_BUCKET}
-        endpoint          {$R2_ENDPOINT}
+        bucket            {env.R2_BUCKET}
+        endpoint          {env.R2_ENDPOINT}
         region            auto
-        access_key_id     {$AWS_ACCESS_KEY_ID}
-        secret_access_key {$AWS_SECRET_ACCESS_KEY}
+        access_key_id     {env.AWS_ACCESS_KEY_ID}
+        secret_access_key {env.AWS_SECRET_ACCESS_KEY}
         use_path_style
         max_file_size     33554432
         # Code defaults, not set here. Truth lives in the named constants in
         # caddy-r2alias/filesystem.go.
         #   (no knob)      30s      opTimeout, bounds every S3 round trip
       }
+    }
+
+    :9180 {
+      metrics /metrics
     }
 
     :80 {
@@ -47,11 +55,11 @@ data:
         header Cache-Control "public, max-age=0, must-revalidate"
 
         r2_alias {
-          bucket            {$R2_BUCKET}
-          endpoint          {$R2_ENDPOINT}
+          bucket            {env.R2_BUCKET}
+          endpoint          {env.R2_ENDPOINT}
           region            auto
-          access_key_id     {$AWS_ACCESS_KEY_ID}
-          secret_access_key {$AWS_SECRET_ACCESS_KEY}
+          access_key_id     {env.AWS_ACCESS_KEY_ID}
+          secret_access_key {env.AWS_SECRET_ACCESS_KEY}
           cache_ttl         15s
           cache_max_entries 10000
           # Code defaults, not set here. Truth lives in the named constants in
@@ -71,12 +79,16 @@ data:
 
       handle_errors {
         header Cache-Control "no-store"
+        header -Etag
 
         @404 expression {err.status_code} == 404
         respond @404 "Not Found" 404
 
         @400 expression {err.status_code} == 400
         respond @400 "Bad Request" 400
+
+        @405 expression {err.status_code} == 405
+        respond @405 "Method Not Allowed" 405
 
         @503 expression {err.status_code} == 503
         respond @503 "Service Unavailable" 503

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
@@ -20,10 +20,9 @@ data:
         access_key_id     {$AWS_ACCESS_KEY_ID}
         secret_access_key {$AWS_SECRET_ACCESS_KEY}
         use_path_style
+        max_file_size     33554432
         # Code defaults, not set here. Truth lives in the named constants in
         # caddy-r2alias/filesystem.go.
-        #   max_file_size  100 MiB  defaultMaxFileSize
-        #     A larger object answers the visitor 400, not 413.
         #   (no knob)      30s      opTimeout, bounds every S3 round trip
       }
     }
@@ -45,7 +44,7 @@ data:
 
       handle {
         # https://developers.cloudflare.com/cache/how-to/edge-browser-cache-ttl/
-        header Cache-Control "public, max-age=0, must-revalidate, s-maxage=86400"
+        header Cache-Control "public, max-age=0, must-revalidate"
 
         r2_alias {
           bucket            {$R2_BUCKET}

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/configmap.yaml
@@ -76,6 +76,9 @@ data:
         @404 expression {err.status_code} == 404
         respond @404 "Not Found" 404
 
+        @400 expression {err.status_code} == 400
+        respond @400 "Bad Request" 400
+
         @503 expression {err.status_code} == 503
         respond @503 "Service Unavailable" 503
 

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/deployment.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
           envFrom:
             - secretRef:
                 name: {{ .Release.Name }}-r2-credentials

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/deployment.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: {{ .Values.goMemLimit | quote }}
           envFrom:
             - secretRef:
                 name: {{ .Release.Name }}-r2-credentials

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/networkpolicy.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/networkpolicy.yaml
@@ -41,4 +41,10 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "{{ .Values.metrics.port }}"
+              protocol: TCP
 {{- end }}

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/service.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
   selector:
     {{- include "caddy.selectorLabels" . | nindent 4 }}

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/values.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/values.yaml
@@ -12,6 +12,9 @@ image:
   tag: "dev"
   pullPolicy: IfNotPresent
 
+metrics:
+  port: 9180
+
 resources:
   requests:
     cpu: 50m

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/values.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/values.yaml
@@ -15,6 +15,8 @@ image:
 metrics:
   port: 9180
 
+goMemLimit: 400MiB
+
 resources:
   requests:
     cpu: 50m

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/values.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/values.yaml
@@ -15,7 +15,7 @@ image:
 metrics:
   port: 9180
 
-goMemLimit: 400MiB
+goMemLimit: 200MiB
 
 resources:
   requests:

--- a/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/values.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/charts/caddy/values.yaml
@@ -15,7 +15,7 @@ image:
 metrics:
   port: 9180
 
-goMemLimit: 200MiB
+goMemLimit: 400MiB
 
 resources:
   requests:
@@ -23,7 +23,7 @@ resources:
     memory: 64Mi
   limits:
     cpu: 500m
-    memory: 256Mi
+    memory: 512Mi
 
 podSecurityContext:
   runAsNonRoot: true

--- a/k3s/gxy-cassiopeia/apps/caddy/values.production.yaml
+++ b/k3s/gxy-cassiopeia/apps/caddy/values.production.yaml
@@ -26,6 +26,8 @@ resources:
     cpu: 1000m
     memory: 512Mi
 
+goMemLimit: 400MiB
+
 r2:
   bucket: universe-static-apps-01
   # endpoint + accessKeyId + secretAccessKey come from the sops overlay


### PR DESCRIPTION
 Serving *.freecode.camp from R2 had two faults. During an R2 outage a page answered 200 with an empty body, so status alerting stayed silent. And nothing told browsers how long to keep a page, so a takedown could leave it on screen for four hours.

 Now a failed fetch answers an error status, and every page tells the browser to revalidate. Each deploy also gets its own validator, so a returning visitor never sees the previous deploy's page.

 The serve plane reports itself for the first time: request counts, R2 call outcomes, cache hits and misses, and the memory it holds, on a metrics port the cluster can scrape.

 Memory is now capped. A flood of large files answers an error instead of killing the pod.

 One step is deliberately not in this change: the Cloudflare zone still overrides the new browser setting. Flip freecode.camp Browser Cache TTL to "Respect Existing Headers" after this deploys, or the header does nothing.
